### PR TITLE
Fix CORS for Vercel preview + tunnel

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,10 +23,7 @@ app = FastAPI(title="AImplify", version="0.1.0", lifespan=lifespan)
 # CORS: allow the Next.js frontend in dev and any Vercel preview deployment
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        FRONTEND_URL,
-        "http://localhost:3000",
-    ],
+    allow_origins=["*"],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary

- Opens CORS to allow all origins during development
- Enables Vercel preview deployments to reach the backend via Cloudflare tunnel

## Test Plan

- [ ] Vercel preview deployment can call `/api/chat` without CORS errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)