### PR TITLE
Phase 2A: Google OAuth setup

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,7 @@
 ANTHROPIC_API_KEY=your-key-here
 DATABASE_URL=sqlite:///aImplify.db
 FRONTEND_URL=http://localhost:3000
+ENCRYPTION_KEY=generate-with-python-cryptography-fernet
+GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+BACKEND_URL=http://localhost:8000

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -8,3 +8,11 @@ ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY", "")
 DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///aImplify.db")
 FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:3000")
 CLAUDE_MODEL = "claude-sonnet-4-20250514"
+
+# Token encryption
+ENCRYPTION_KEY = os.getenv("ENCRYPTION_KEY", "")
+
+# Google OAuth
+GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID", "")
+GOOGLE_CLIENT_SECRET = os.getenv("GOOGLE_CLIENT_SECRET", "")
+BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -27,7 +27,7 @@ _MIGRATIONS = [
 
 def init_db():
     """Create all tables if they don't exist, then run migrations."""
-    from app.models import user, business, conversation, workflow, activity_log  # noqa: F401
+    from app.models import user, business, conversation, workflow, activity_log, integration  # noqa: F401
     Base.metadata.create_all(bind=engine)
 
     # Run pending migrations (skip if column already exists)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,7 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import FRONTEND_URL
 from app.database import init_db
-from app.routers import health, chat, workflows
+from app.routers import health, chat, workflows, integrations
 
 
 @asynccontextmanager
@@ -33,3 +33,4 @@ app.add_middleware(
 app.include_router(health.router)
 app.include_router(chat.router)
 app.include_router(workflows.router)
+app.include_router(integrations.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -3,6 +3,7 @@ from app.models.business import Business
 from app.models.conversation import Conversation, Message
 from app.models.workflow import Workflow, WorkflowStep
 from app.models.activity_log import ActivityLog
+from app.models.integration import Integration
 
 __all__ = [
     "User",
@@ -12,4 +13,5 @@ __all__ = [
     "Workflow",
     "WorkflowStep",
     "ActivityLog",
+    "Integration",
 ]

--- a/backend/app/models/integration.py
+++ b/backend/app/models/integration.py
@@ -1,0 +1,24 @@
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class Integration(Base):
+    __tablename__ = "integrations"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    provider: Mapped[str] = mapped_column(String(50), unique=True, index=True)
+    access_token: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    refresh_token: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    token_expiry: Mapped[Optional[datetime]] = mapped_column(nullable=True)
+    scopes: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    status: Mapped[str] = mapped_column(String(20), default="disconnected")
+    created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(timezone.utc))
+    updated_at: Mapped[datetime] = mapped_column(
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )

--- a/backend/app/routers/integrations.py
+++ b/backend/app/routers/integrations.py
@@ -1,0 +1,135 @@
+from typing import List
+
+import requests as http_requests
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import RedirectResponse
+from google_auth_oauthlib.flow import Flow
+from sqlalchemy.orm import Session
+
+from app.config import (
+    GOOGLE_CLIENT_ID,
+    GOOGLE_CLIENT_SECRET,
+    BACKEND_URL,
+    FRONTEND_URL,
+)
+from app.database import get_db
+from app.models.integration import Integration
+from app.services.encryption import encrypt_token, decrypt_token
+
+router = APIRouter(prefix="/api")
+
+# Scopes for Gmail and Calendar access
+GOOGLE_SCOPES = [
+    "https://www.googleapis.com/auth/gmail.modify",
+    "https://www.googleapis.com/auth/calendar",
+    "openid",
+    "https://www.googleapis.com/auth/userinfo.email",
+]
+
+GOOGLE_CLIENT_CONFIG = {
+    "web": {
+        "client_id": GOOGLE_CLIENT_ID,
+        "client_secret": GOOGLE_CLIENT_SECRET,
+        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+        "token_uri": "https://oauth2.googleapis.com/token",
+    }
+}
+
+
+def _make_flow() -> Flow:
+    return Flow.from_client_config(
+        GOOGLE_CLIENT_CONFIG,
+        scopes=GOOGLE_SCOPES,
+        redirect_uri=f"{BACKEND_URL}/api/integrations/google/callback",
+    )
+
+
+@router.get("/integrations/google/connect")
+async def google_connect():
+    """Redirect the user to Google's OAuth consent screen."""
+    flow = _make_flow()
+    authorization_url, _ = flow.authorization_url(
+        access_type="offline",
+        include_granted_scopes="true",
+        prompt="consent",
+    )
+    return RedirectResponse(url=authorization_url)
+
+
+@router.get("/integrations/google/callback")
+async def google_callback(code: str, db: Session = Depends(get_db)):
+    """Handle the OAuth callback — exchange code for tokens and store them."""
+    flow = _make_flow()
+    flow.fetch_token(code=code)
+
+    credentials = flow.credentials
+
+    encrypted_access = encrypt_token(credentials.token)
+    encrypted_refresh = (
+        encrypt_token(credentials.refresh_token) if credentials.refresh_token else None
+    )
+
+    # Upsert integration row
+    integration = db.query(Integration).filter(Integration.provider == "google").first()
+    if integration:
+        integration.access_token = encrypted_access
+        integration.refresh_token = encrypted_refresh or integration.refresh_token
+        integration.token_expiry = credentials.expiry
+        integration.scopes = " ".join(credentials.scopes or GOOGLE_SCOPES)
+        integration.status = "connected"
+    else:
+        integration = Integration(
+            provider="google",
+            access_token=encrypted_access,
+            refresh_token=encrypted_refresh,
+            token_expiry=credentials.expiry,
+            scopes=" ".join(credentials.scopes or GOOGLE_SCOPES),
+            status="connected",
+        )
+        db.add(integration)
+
+    db.commit()
+    return RedirectResponse(url=f"{FRONTEND_URL}/settings/integrations?status=success")
+
+
+@router.get("/integrations/status")
+async def integrations_status(db: Session = Depends(get_db)):
+    """Return the status of all integrations. Never exposes tokens."""
+    integrations = db.query(Integration).all()
+    return [
+        {
+            "provider": i.provider,
+            "status": i.status,
+            "scopes": i.scopes.split(" ") if i.scopes else [],
+            "connected_at": i.updated_at.isoformat() if i.status == "connected" else None,
+        }
+        for i in integrations
+    ]
+
+
+@router.post("/integrations/google/disconnect")
+async def google_disconnect(db: Session = Depends(get_db)):
+    """Revoke the Google token and mark as disconnected."""
+    integration = db.query(Integration).filter(Integration.provider == "google").first()
+    if not integration:
+        raise HTTPException(status_code=404, detail="Google integration not found")
+
+    # Best-effort revocation with Google
+    if integration.access_token:
+        try:
+            token = decrypt_token(integration.access_token)
+            http_requests.post(
+                "https://oauth2.googleapis.com/revoke",
+                params={"token": token},
+                timeout=5,
+            )
+        except Exception:
+            pass
+
+    integration.access_token = None
+    integration.refresh_token = None
+    integration.token_expiry = None
+    integration.status = "disconnected"
+    db.commit()
+
+    return {"status": "disconnected"}

--- a/backend/app/schemas/integration.py
+++ b/backend/app/schemas/integration.py
@@ -1,0 +1,12 @@
+from typing import Optional, List
+from pydantic import BaseModel
+
+
+class IntegrationStatus(BaseModel):
+    provider: str
+    status: str
+    scopes: List[str] = []
+    connected_at: Optional[str] = None
+
+    class Config:
+        from_attributes = True

--- a/backend/app/services/encryption.py
+++ b/backend/app/services/encryption.py
@@ -1,0 +1,18 @@
+from cryptography.fernet import Fernet
+from app.config import ENCRYPTION_KEY
+
+_fernet = Fernet(ENCRYPTION_KEY.encode()) if ENCRYPTION_KEY else None
+
+
+def encrypt_token(plaintext: str) -> str:
+    """Encrypt a token string and return the ciphertext as a UTF-8 string."""
+    if not _fernet:
+        raise RuntimeError("ENCRYPTION_KEY is not configured")
+    return _fernet.encrypt(plaintext.encode()).decode()
+
+
+def decrypt_token(ciphertext: str) -> str:
+    """Decrypt a ciphertext string and return the original token."""
+    if not _fernet:
+        raise RuntimeError("ENCRYPTION_KEY is not configured")
+    return _fernet.decrypt(ciphertext.encode()).decode()

--- a/backend/app/services/google_auth.py
+++ b/backend/app/services/google_auth.py
@@ -1,0 +1,47 @@
+"""Google OAuth credential management — single point of access for all Google API calls."""
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from sqlalchemy.orm import Session
+
+from app.config import GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET
+from app.models.integration import Integration
+from app.services.encryption import encrypt_token, decrypt_token
+
+
+def get_google_credentials(db: Session) -> Optional[Credentials]:
+    """Get valid Google credentials, refreshing if expired.
+
+    Returns None if no Google integration is connected.
+    """
+    integration = db.query(Integration).filter(
+        Integration.provider == "google",
+        Integration.status == "connected",
+    ).first()
+
+    if not integration or not integration.access_token:
+        return None
+
+    creds = Credentials(
+        token=decrypt_token(integration.access_token),
+        refresh_token=decrypt_token(integration.refresh_token) if integration.refresh_token else None,
+        token_uri="https://oauth2.googleapis.com/token",
+        client_id=GOOGLE_CLIENT_ID,
+        client_secret=GOOGLE_CLIENT_SECRET,
+    )
+
+    # Refresh if expired
+    if integration.token_expiry and integration.token_expiry < datetime.now(timezone.utc):
+        if creds.refresh_token:
+            creds.refresh(Request())
+            # Update stored tokens with fresh ones
+            integration.access_token = encrypt_token(creds.token)
+            integration.token_expiry = creds.expiry
+            db.commit()
+        else:
+            return None  # No refresh token — user must re-auth
+
+    return creds

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,6 @@ sqlalchemy
 anthropic
 python-dotenv
 pydantic
+cryptography
+google-auth-oauthlib
+google-api-python-client

--- a/frontend/src/app/settings/integrations/page.tsx
+++ b/frontend/src/app/settings/integrations/page.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useState, useEffect, Suspense } from "react";
+import { useSearchParams } from "next/navigation";
+import { api } from "@/lib/api";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+interface IntegrationStatus {
+  provider: string;
+  status: string;
+  scopes: string[];
+  connected_at: string | null;
+}
+
+function IntegrationsContent() {
+  const [integrations, setIntegrations] = useState<IntegrationStatus[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [disconnecting, setDisconnecting] = useState(false);
+  const searchParams = useSearchParams();
+  const justConnected = searchParams.get("status") === "success";
+
+  useEffect(() => {
+    fetchStatus();
+  }, []);
+
+  async function fetchStatus() {
+    try {
+      const data = await api.get<IntegrationStatus[]>(
+        "/api/integrations/status"
+      );
+      setIntegrations(data);
+    } catch {
+      // Backend might not be reachable
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleDisconnect() {
+    setDisconnecting(true);
+    try {
+      await api.post("/api/integrations/google/disconnect", {});
+      await fetchStatus();
+    } catch {
+      // Best effort
+    } finally {
+      setDisconnecting(false);
+    }
+  }
+
+  const google = integrations.find((i) => i.provider === "google");
+  const isConnected = google?.status === "connected";
+
+  const scopeLabels: Record<string, string> = {
+    "https://www.googleapis.com/auth/gmail.modify": "Gmail",
+    "https://www.googleapis.com/auth/calendar": "Calendar",
+    "https://www.googleapis.com/auth/userinfo.email": "Email",
+    openid: "Sign-in",
+  };
+
+  return (
+    <div className="p-6 max-w-2xl">
+      <h1 className="text-xl font-semibold text-stone-900">
+        Connected Accounts
+      </h1>
+      <p className="text-sm text-stone-500 mt-1">
+        Connect your tools so AImplify can work with them.
+      </p>
+
+      {justConnected && (
+        <div className="mt-4 bg-green-50 border border-green-200 rounded-lg px-4 py-3 text-sm text-green-700">
+          Google account connected successfully!
+        </div>
+      )}
+
+      <div className="mt-6 border border-stone-200 rounded-xl p-5">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 rounded-lg bg-stone-100 flex items-center justify-center text-lg">
+              G
+            </div>
+            <div>
+              <h3 className="font-medium text-stone-900">Google</h3>
+              <p className="text-xs text-stone-500">
+                Gmail and Google Calendar access
+              </p>
+            </div>
+          </div>
+
+          <span
+            className={`text-xs font-medium px-2.5 py-1 rounded-full ${
+              isConnected
+                ? "bg-green-100 text-green-700"
+                : "bg-stone-100 text-stone-500"
+            }`}
+          >
+            {isConnected ? "Connected" : "Not connected"}
+          </span>
+        </div>
+
+        {isConnected && google?.scopes && (
+          <div className="mt-3 flex flex-wrap gap-1.5">
+            {google.scopes.map((scope) => (
+              <span
+                key={scope}
+                className="text-xs bg-stone-50 text-stone-600 px-2 py-0.5 rounded"
+              >
+                {scopeLabels[scope] || scope}
+              </span>
+            ))}
+          </div>
+        )}
+
+        <div className="mt-4">
+          {isConnected ? (
+            <button
+              onClick={handleDisconnect}
+              disabled={disconnecting}
+              className="px-4 py-2 text-sm rounded-lg border border-red-200 text-red-600 hover:bg-red-50 transition-colors disabled:opacity-50"
+            >
+              {disconnecting ? "Disconnecting..." : "Disconnect"}
+            </button>
+          ) : (
+            <a
+              href={`${API_URL}/api/integrations/google/connect`}
+              className="inline-flex items-center px-4 py-2 text-sm rounded-lg bg-primary text-white font-semibold hover:bg-primary-hover transition-colors"
+            >
+              Connect Google Account
+            </a>
+          )}
+        </div>
+      </div>
+
+      {loading && (
+        <p className="mt-4 text-sm text-stone-400">Loading status...</p>
+      )}
+    </div>
+  );
+}
+
+export default function IntegrationsPage() {
+  return (
+    <Suspense>
+      <IntegrationsContent />
+    </Suspense>
+  );
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -7,6 +7,7 @@ const navItems = [
   { href: "/", label: "Home", icon: "🏠" },
   { href: "/chat", label: "Chat", icon: "💬" },
   { href: "/dashboard", label: "Dashboard", icon: "📊" },
+  { href: "/settings/integrations", label: "Settings", icon: "⚙️" },
 ];
 
 export function Sidebar() {
@@ -23,7 +24,10 @@ export function Sidebar() {
 
       <nav className="flex-1 px-3 py-4 space-y-1">
         {navItems.map((item) => {
-          const isActive = pathname === item.href;
+          const isActive =
+            item.href === "/"
+              ? pathname === "/"
+              : pathname.startsWith(item.href);
           return (
             <Link
               key={item.href}


### PR DESCRIPTION
## Summary
- **Google OAuth flow**: Connect → redirect to Google consent → callback stores encrypted tokens → redirect to settings page with success banner
- **Fernet encryption**: All OAuth tokens encrypted at rest using `ENCRYPTION_KEY` from `.env`
- **Integration model**: Stores provider, encrypted tokens, expiry, scopes, status — no user_id yet (single-user until Phase 6)
- **Auto-refresh**: `get_google_credentials()` helper automatically refreshes expired access tokens using the refresh token
- **Connected Accounts page**: `/settings/integrations` shows Google card with status badge, scope labels, and Connect/Disconnect buttons
- **Sidebar**: New "Settings" link with gear icon

## Test Plan
1. **Settings page**: Click "Settings" in the sidebar — you should see the "Connected Accounts" page with a Google card showing "Not connected" and a "Connect Google Account" button
2. **OAuth flow** (requires Google Cloud credentials in `.env`):
   - Click "Connect Google Account" — should redirect to Google's consent screen
   - Authorize — should redirect back to `/settings/integrations?status=success` with a green success banner
   - Google card should now show "Connected" with scope labels (Gmail, Calendar, etc.)
3. **Disconnect**: Click "Disconnect" — status should change back to "Not connected"
4. **API check**: `GET /api/integrations/status` should return the correct status

> **Setup required**: You need to create a Google Cloud project, enable Gmail API + Calendar API, create OAuth 2.0 credentials (web app type), and set `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, and `BACKEND_URL` in your `.env` file. Set the authorized redirect URI to `{BACKEND_URL}/api/integrations/google/callback`.

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)