### PR TITLE
Phase 17A: Multiple choice buttons for chat discovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,10 +25,19 @@ AI operations layer for medspas. Owners describe how their business works in pla
 ## Signal Tag System
 - AI embeds hidden XML tags in responses (e.g., `<action_request>send_email</action_request>`) to trigger backend actions
 - Tags are parsed in `parse_ai_response()` in `ai_engine.py`, stripped from user-visible content
-- Current tags: `action_request`, `action_confirmed`, `workflow_ready`, `workflow_confirmed`, `workflow_manage`, `workflow_manage_confirmed`, `workflow_list`, `workflow_activity`, `workflow_status`, `workflow_run`, `workflow_run_confirmed`, `workflow_schedule`, `workflow_schedule_confirmed`, `workflow_edit`, `workflow_edit_confirmed`, `connect_tool`, `disconnect_tool`, `disconnect_confirmed`
+- Current tags: `action_request`, `action_confirmed`, `workflow_ready`, `workflow_confirmed`, `workflow_manage`, `workflow_manage_confirmed`, `workflow_list`, `workflow_activity`, `workflow_status`, `workflow_run`, `workflow_run_confirmed`, `workflow_schedule`, `workflow_schedule_confirmed`, `workflow_edit`, `workflow_edit_confirmed`, `connect_tool`, `disconnect_tool`, `disconnect_confirmed`, `choices`
 - New action types must be added to: `ACTION_EXTRACTION_TOOLS` (ai_engine.py), `ACTION_PROVIDER` map (chat.py), `_execute_chat_action` (chat.py), `ACTION_LABELS` (MessageBubble.tsx)
 - Handler ordering in chat.py matters: workflow query handlers (list/status/activity/run) must run BEFORE `_detect_action_gathering` safety net to prevent false positives on words like "schedule" in workflow descriptions
 - When adding new AI capabilities via signal tags, the system prompt must assertively state the AI HAS the capability (like connection status does) — otherwise the AI may claim it can't do it
+
+## Choice Buttons
+- `<choices>Option A|Option B|Option C</choices>` renders clickable buttons in the chat UI
+- Pipe-delimited format, 2-4 options, short phrases (2-8 words each)
+- Backend parses in `parse_ai_response()`, builds metadata `{message_type: "choices", choices: [...]}`
+- Frontend `ChoiceButtonsCard` renders buttons; clicking sends the choice text as a user message
+- Only the latest assistant message's buttons are active; older ones render as disabled/muted
+- The `choices` handler in chat.py runs AFTER all other signal handlers — if metadata is already set, choices are appended as extra field but don't override `message_type`
+- Do NOT use `<choices>` for yes/no confirmations (handled by confirmation cards), free-form input, or workflow summary confirmations
 
 ## Time-Based Triggers
 - Background scheduler runs as an asyncio task in FastAPI lifespan, checking every 60s for due workflows

--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -178,6 +178,11 @@ async def chat(request: ChatRequest, db: Session = Depends(get_db)):
                 wf = m.metadata_json.get("workflow", {})
                 logs = m.metadata_json.get("recent_activity", [])
                 content += f"\n\n[System: Status for '{wf.get('name', '')}' was shown — {len(logs)} recent activity entries.]"
+            elif msg_type == "choices":
+                options = m.metadata_json.get("choices", [])
+                if options:
+                    content += f"\n\n[System: Clickable choice buttons were shown: {' / '.join(options)}. " \
+                               "The user may have clicked one of these.]"
         messages.append({"role": m.role, "content": content})
 
     # Get AI response and parse for signal tags
@@ -932,6 +937,14 @@ async def chat(request: ChatRequest, db: Session = Depends(get_db)):
                 "success": False,
                 "error": str(e),
             }
+
+    # ── Attach choices if present ───────────────────────────────────────
+    if signals.get("choices"):
+        if metadata is None:
+            metadata = {"message_type": "choices", "choices": signals["choices"]}
+        else:
+            # Append choices to existing metadata (other card type takes priority)
+            metadata["choices"] = signals["choices"]
 
     # Save assistant message
     assistant_message = Message(

--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -178,11 +178,6 @@ async def chat(request: ChatRequest, db: Session = Depends(get_db)):
                 wf = m.metadata_json.get("workflow", {})
                 logs = m.metadata_json.get("recent_activity", [])
                 content += f"\n\n[System: Status for '{wf.get('name', '')}' was shown — {len(logs)} recent activity entries.]"
-            elif msg_type == "choices":
-                options = m.metadata_json.get("choices", [])
-                if options:
-                    content += f"\n\n[System: Clickable choice buttons were shown: {' / '.join(options)}. " \
-                               "The user may have clicked one of these.]"
         messages.append({"role": m.role, "content": content})
 
     # Get AI response and parse for signal tags

--- a/backend/app/services/ai_engine.py
+++ b/backend/app/services/ai_engine.py
@@ -15,7 +15,15 @@ IMPORTANT RULES:
 "pipeline," or "agent." Instead say things like "the thing that kicks it off," \
 "each step," "the tools you use."
 - Ask ONE question at a time. Never dump a list of questions.
-- When possible, offer 2-4 simple choices instead of open-ended questions.
+- When possible, offer 2-4 simple choices instead of open-ended questions. \
+When you present choices, ALSO include a hidden <choices> tag at the END of your \
+message listing the choices separated by pipes. Example: if your message says \
+"Would you like me to show your calendar or check a specific time?", also add: \
+<choices>Show my calendar|Check a specific time</choices> \
+RULES for <choices>: each option should be short (2-8 words), no numbering or bullets, \
+2-4 options max. Do NOT use <choices> for yes/no confirmations, free-form input \
+(names, emails, times), or workflow summary confirmations. The tag is hidden — the user \
+sees clickable buttons rendered from it. You still write choices naturally in your text.
 - Keep responses short and conversational — 2-3 sentences max per turn.
 {connection_status}
 - In PREVIOUS messages in this conversation, you may see "[System: ...]" notes appended \
@@ -683,6 +691,15 @@ def parse_ai_response(raw_content: str) -> dict:
     if workflow_edit_confirmed_match:
         workflow_edit_confirmed = workflow_edit_confirmed_match.group(1).strip()
 
+    # Extract choices (e.g., <choices>Option A|Option B|Option C</choices>)
+    choices = None
+    choices_match = re.search(r"<choices>(.+?)</choices>", raw_content)
+    if choices_match:
+        raw_choices = choices_match.group(1).strip()
+        choices = [c.strip() for c in raw_choices.split("|") if c.strip()]
+        if len(choices) < 2 or len(choices) > 4:
+            choices = None  # Reject malformed: must be 2-4 options
+
     clean = raw_content
     clean = clean.replace("<workflow_ready>true</workflow_ready>", "")
     clean = clean.replace("<workflow_confirmed>true</workflow_confirmed>", "")
@@ -716,6 +733,8 @@ def parse_ai_response(raw_content: str) -> dict:
         clean = clean.replace(workflow_edit_match.group(0), "")
     if workflow_edit_confirmed_match:
         clean = clean.replace(workflow_edit_confirmed_match.group(0), "")
+    if choices_match:
+        clean = clean.replace(choices_match.group(0), "")
     clean = clean.strip()
 
     return {
@@ -738,6 +757,7 @@ def parse_ai_response(raw_content: str) -> dict:
         "workflow_schedule_confirmed": workflow_schedule_confirmed,
         "workflow_edit": workflow_edit,
         "workflow_edit_confirmed": workflow_edit_confirmed,
+        "choices": choices,
     }
 
 

--- a/backend/app/services/ai_engine.py
+++ b/backend/app/services/ai_engine.py
@@ -735,6 +735,8 @@ def parse_ai_response(raw_content: str) -> dict:
         clean = clean.replace(workflow_edit_confirmed_match.group(0), "")
     if choices_match:
         clean = clean.replace(choices_match.group(0), "")
+    # Strip any [System: ...] text the AI may echo from its history
+    clean = re.sub(r"\[System:.*?\]", "", clean)
     clean = clean.strip()
 
     return {

--- a/frontend/src/components/ChatWindow.tsx
+++ b/frontend/src/components/ChatWindow.tsx
@@ -31,6 +31,7 @@ interface MessageMetadata {
   query?: string;
   provider?: string;
   error?: string;
+  choices?: string[];
 }
 
 interface Message {
@@ -130,6 +131,46 @@ export function ChatWindow({ conversationId, onConversationCreated }: ChatWindow
       window.location.href = `${API_URL}/api/integrations/${provider}/connect`;
     }
   }, []);
+
+  // ── Choice button handling ────────────────────────────────────────────
+  const handleChoiceSelect = useCallback(
+    async (choiceText: string) => {
+      if (loading) return;
+
+      const userMsg: Message = { id: Date.now(), role: "user", content: choiceText };
+      setMessages((prev) => [...prev, userMsg]);
+      setLoading(true);
+
+      const sendId = conversationId ?? createdIdRef.current;
+
+      try {
+        const data = await api.post<ChatResponse>("/api/chat", {
+          message: choiceText,
+          conversation_id: sendId,
+          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        });
+
+        if (!sendId && data.conversation_id) {
+          createdIdRef.current = data.conversation_id;
+          onConversationCreated?.(data.conversation_id);
+        }
+
+        setMessages((prev) => [...prev, data.message]);
+      } catch {
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: Date.now(),
+            role: "assistant",
+            content: "Sorry, something went wrong. Please try again.",
+          },
+        ]);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [loading, conversationId, onConversationCreated]
+  );
 
   useEffect(() => {
     const VALID_PROVIDERS = ["gmail", "google_calendar"];
@@ -252,15 +293,23 @@ export function ChatWindow({ conversationId, onConversationCreated }: ChatWindow
             Start by describing a task you do repeatedly.
           </div>
         )}
-        {messages.map((msg) => (
-          <MessageBubble
-            key={msg.id}
-            role={msg.role}
-            content={msg.content}
-            metadata={msg.metadata}
-            onConnectTool={handleConnectTool}
-          />
-        ))}
+        {(() => {
+          const lastAssistantId = messages
+            .filter((m) => m.role === "assistant")
+            .at(-1)?.id;
+          return messages.map((msg) => (
+            <MessageBubble
+              key={msg.id}
+              role={msg.role}
+              content={msg.content}
+              metadata={msg.metadata}
+              onConnectTool={handleConnectTool}
+              onChoiceSelect={handleChoiceSelect}
+              isLatestAssistant={msg.role === "assistant" && msg.id === lastAssistantId}
+              loading={loading}
+            />
+          ));
+        })()}
         {loading && (
           <div className="flex justify-start">
             <div className="bg-stone-100 rounded-2xl px-4 py-3 text-sm text-stone-400 rounded-bl-md">

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -62,6 +62,7 @@ interface MessageMetadata {
   new_schedule?: string;
   next_run_at?: string;
   current_schedule?: string;
+  choices?: string[];
 }
 
 interface MessageBubbleProps {
@@ -69,9 +70,12 @@ interface MessageBubbleProps {
   content: string;
   metadata?: MessageMetadata | null;
   onConnectTool?: (provider: string) => void;
+  onChoiceSelect?: (choice: string) => void;
+  isLatestAssistant?: boolean;
+  loading?: boolean;
 }
 
-export function MessageBubble({ role, content, metadata, onConnectTool }: MessageBubbleProps) {
+export function MessageBubble({ role, content, metadata, onConnectTool, onChoiceSelect, isLatestAssistant, loading }: MessageBubbleProps) {
   const isUser = role === "user";
 
   // Workflow confirmed — show success banner
@@ -484,6 +488,36 @@ export function MessageBubble({ role, content, metadata, onConnectTool }: Messag
             {content}
           </div>
           <WorkflowSummaryCard draft={metadata.workflow_draft} />
+        </div>
+      </div>
+    );
+  }
+
+  // Choices — show clickable buttons below the message
+  if (metadata?.message_type === "choices" && metadata.choices?.length) {
+    const isActive = isLatestAssistant && !loading;
+    return (
+      <div className="flex justify-start">
+        <div className="max-w-[75%] space-y-3">
+          <div className="bg-stone-100 rounded-2xl px-4 py-3 text-sm leading-relaxed text-stone-800 rounded-bl-md">
+            {content}
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {metadata.choices.map((choice) => (
+              <button
+                key={choice}
+                onClick={() => onChoiceSelect?.(choice)}
+                disabled={!isActive}
+                className={`px-4 py-2 text-sm rounded-lg border-2 transition-colors ${
+                  isActive
+                    ? "border-blue-300 bg-blue-50 text-blue-800 font-medium hover:bg-blue-100 hover:border-blue-400 cursor-pointer"
+                    : "border-stone-200 bg-stone-50 text-stone-400 cursor-default"
+                }`}
+              >
+                {choice}
+              </button>
+            ))}
+          </div>
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary
- Adds `<choices>` signal tag: AI emits pipe-delimited options alongside its text, backend parses into `{message_type: "choices", choices: [...]}` metadata
- Frontend renders clickable `ChoiceButtonsCard` below the message bubble — clicking sends the choice as a user message automatically
- Only the latest assistant message's buttons are active; older ones render as disabled/muted (stone colors)
- Choices handler runs after all other signal handlers — never overrides action/workflow cards

Closes #90

## Test plan
- [ ] Start a new conversation: "I want to set up something that runs automatically"
- [ ] AI should respond with clickable buttons (e.g., "Every day" / "When I get an email" / "Before a calendar event")
- [ ] Click a button — it appears as your message, AI responds with next question
- [ ] Previous choice buttons should be grayed out / not clickable
- [ ] Continue clicking through discovery — each question should have buttons
- [ ] Refresh the page — all choice buttons should load as disabled
- [ ] Test ambiguity flows: "What's on my calendar?" should offer "Show my calendar" / "Check a specific time" buttons
- [ ] Verify confirmation cards (action_request, workflow_summary) still render correctly with no interference

🤖 Generated with [Claude Code](https://claude.com/claude-code)