### PR TITLE
Phase 18D: Transparent State & Business Memory

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -24,12 +24,13 @@ _MIGRATIONS = [
     "ALTER TABLE workflows ADD COLUMN conversation_id INTEGER REFERENCES conversations(id)",
     "ALTER TABLE workflows ADD COLUMN next_run_at TIMESTAMP",
     "ALTER TABLE workflows ADD COLUMN last_run_at TIMESTAMP",
+    "ALTER TABLE conversations ADD COLUMN session_context JSON",
 ]
 
 
 def init_db():
     """Create all tables if they don't exist, then run migrations."""
-    from app.models import user, business, conversation, workflow, activity_log, integration  # noqa: F401
+    from app.models import user, business, conversation, workflow, activity_log, integration, memory  # noqa: F401
     Base.metadata.create_all(bind=engine)
 
     # Run pending migrations (skip if column already exists)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,7 +6,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import FRONTEND_URL
 from app.database import init_db
-from app.routers import health, chat, workflows, integrations, actions
+from app.routers import health, chat, workflows, integrations, actions, memory
 from app.services.scheduler import scheduler_loop
 from app.services.email_watcher import email_watcher_loop
 from app.services.calendar_watcher import calendar_watcher_loop
@@ -50,3 +50,4 @@ app.include_router(chat.router)
 app.include_router(workflows.router)
 app.include_router(integrations.router)
 app.include_router(actions.router)
+app.include_router(memory.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -4,6 +4,7 @@ from app.models.conversation import Conversation, Message
 from app.models.workflow import Workflow, WorkflowStep
 from app.models.activity_log import ActivityLog
 from app.models.integration import Integration
+from app.models.memory import BusinessMemory
 
 __all__ = [
     "User",
@@ -14,4 +15,5 @@ __all__ = [
     "WorkflowStep",
     "ActivityLog",
     "Integration",
+    "BusinessMemory",
 ]

--- a/backend/app/models/conversation.py
+++ b/backend/app/models/conversation.py
@@ -18,6 +18,7 @@ class Conversation(Base):
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
     )
+    session_context: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
 
     business: Mapped[Optional["Business"]] = relationship(back_populates="conversations")
     messages: Mapped[List["Message"]] = relationship(

--- a/backend/app/models/memory.py
+++ b/backend/app/models/memory.py
@@ -1,0 +1,27 @@
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import String, ForeignKey, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class BusinessMemory(Base):
+    __tablename__ = "business_memories"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    business_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("businesses.id"), nullable=True
+    )
+    category: Mapped[str] = mapped_column(String(100), default="general")
+    key: Mapped[str] = mapped_column(String(255))
+    value: Mapped[str] = mapped_column(Text)
+    source: Mapped[str] = mapped_column(String(50), default="chat")
+    created_at: Mapped[datetime] = mapped_column(
+        default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )

--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -15,6 +15,7 @@ from app.schemas.chat import (
 )
 from app.models.activity_log import ActivityLog
 from app.models.integration import Integration
+from app.models.memory import BusinessMemory
 from app.models.workflow import Workflow
 from app.services.ai_engine import (
     get_ai_response,
@@ -178,6 +179,18 @@ async def chat(request: ChatRequest, db: Session = Depends(get_db)):
                 wf = m.metadata_json.get("workflow", {})
                 logs = m.metadata_json.get("recent_activity", [])
                 content += f"\n\n[System: Status for '{wf.get('name', '')}' was shown — {len(logs)} recent activity entries.]"
+            elif msg_type == "memory_save_request":
+                mem_key = m.metadata_json.get("memory_key", "")
+                content += f"\n\n[System: A confirmation card to save '{mem_key}' to business memory is being shown. " \
+                           "When they confirm, respond with a short acknowledgment and use <memory_save_confirmed>true</memory_save_confirmed> — " \
+                           "do NOT re-summarize or show another <memory_save>.]"
+            elif msg_type == "memory_save_result":
+                success = m.metadata_json.get("success", False)
+                mem_key = m.metadata_json.get("memory_key", "")
+                if success:
+                    content += f"\n\n[System: '{mem_key}' was saved to business memory successfully.]"
+                else:
+                    content += f"\n\n[System: Failed to save '{mem_key}' to business memory.]"
         messages.append({"role": m.role, "content": content})
 
     # Get AI response and parse for signal tags
@@ -190,6 +203,18 @@ async def chat(request: ChatRequest, db: Session = Depends(get_db)):
         Integration.status == "connected"
     ).all()
     connected_providers = [i.provider for i in connected_integrations]
+
+    # Query business memories for prompt injection (Tier 3)
+    all_memories = db.query(BusinessMemory).order_by(
+        BusinessMemory.category, BusinessMemory.updated_at.desc()
+    ).all()
+    business_memories = [
+        {"category": m.category, "key": m.key, "value": m.value}
+        for m in all_memories
+    ] if all_memories else None
+
+    # Load session context (Tier 2) from the conversation
+    session_context = conversation.session_context
 
     # ── Pre-flight: check if the user's message implies a disconnected tool ──
     # Catches tool needs early — before calling the AI or starting workflow
@@ -226,6 +251,8 @@ async def chat(request: ChatRequest, db: Session = Depends(get_db)):
     raw_content = await get_ai_response(
         messages, timezone=tz, workflow_names=wf_names,
         connected_providers=connected_providers,
+        business_memories=business_memories,
+        session_context=session_context,
     )
     signals = parse_ai_response(raw_content)
     clean_content = signals["clean_content"]
@@ -238,6 +265,12 @@ async def chat(request: ChatRequest, db: Session = Depends(get_db)):
         draft = await extract_workflow_from_conversation(messages)
         if draft:
             metadata = {"message_type": "workflow_summary", "workflow_draft": draft}
+        # Track the current task in session context (Tier 2)
+        if not conversation.session_context:
+            conversation.session_context = {}
+        conversation.session_context["task"] = "setting up a workflow"
+        from sqlalchemy.orm.attributes import flag_modified
+        flag_modified(conversation, "session_context")
 
     if signals["workflow_confirmed"]:
         # Safety check: if a workflow already exists for this conversation,
@@ -933,6 +966,43 @@ async def chat(request: ChatRequest, db: Session = Depends(get_db)):
                 "error": str(e),
             }
 
+    # ── Memory save (suggest saving to business memory) ─────────────────
+    if signals.get("memory_save") and not metadata:
+        mem = signals["memory_save"]
+        metadata = {
+            "message_type": "memory_save_request",
+            "memory_category": mem["category"],
+            "memory_key": mem["key"],
+            "memory_value": mem["value"],
+        }
+    elif signals.get("memory_save") and metadata:
+        # Don't override existing metadata, stash for later
+        metadata["pending_memory"] = signals["memory_save"]
+
+    if signals.get("memory_save_confirmed") and not metadata:
+        prior_memory = _find_latest_memory_request(db, conversation.id)
+        if prior_memory:
+            new_memory = BusinessMemory(
+                category=prior_memory["memory_category"],
+                key=prior_memory["memory_key"],
+                value=prior_memory["memory_value"],
+                source="chat",
+            )
+            db.add(new_memory)
+            metadata = {
+                "message_type": "memory_save_result",
+                "success": True,
+                "memory_key": prior_memory["memory_key"],
+            }
+            # Also note in session context
+            if not conversation.session_context:
+                conversation.session_context = {}
+            saved_list = conversation.session_context.get("recently_saved", [])
+            saved_list.append(prior_memory["memory_key"])
+            conversation.session_context["recently_saved"] = saved_list
+            from sqlalchemy.orm.attributes import flag_modified
+            flag_modified(conversation, "session_context")
+
     # ── Attach choices if present ───────────────────────────────────────
     if signals.get("choices"):
         if metadata is None:
@@ -1281,6 +1351,20 @@ def _find_latest_schedule_request(db: Session, conversation_id: int) -> Optional
     for msg in msgs:
         if msg.metadata_json and isinstance(msg.metadata_json, dict):
             if msg.metadata_json.get("message_type") == "workflow_schedule_request":
+                return msg.metadata_json
+    return None
+
+
+def _find_latest_memory_request(db: Session, conversation_id: int) -> Optional[dict]:
+    """Find the most recent memory_save_request metadata in this conversation."""
+    msgs = db.query(Message).filter(
+        Message.conversation_id == conversation_id,
+        Message.role == "assistant",
+    ).order_by(Message.created_at.desc()).limit(10).all()
+
+    for msg in msgs:
+        if msg.metadata_json and isinstance(msg.metadata_json, dict):
+            if msg.metadata_json.get("message_type") == "memory_save_request":
                 return msg.metadata_json
     return None
 

--- a/backend/app/routers/memory.py
+++ b/backend/app/routers/memory.py
@@ -1,0 +1,87 @@
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models.memory import BusinessMemory
+from app.schemas.memory import (
+    BusinessMemoryCreate,
+    BusinessMemoryUpdate,
+    BusinessMemoryResponse,
+)
+
+router = APIRouter(prefix="/api")
+
+
+@router.get("/memory", response_model=List[BusinessMemoryResponse])
+def list_memories(
+    category: Optional[str] = Query(None),
+    db: Session = Depends(get_db),
+):
+    query = db.query(BusinessMemory).order_by(
+        BusinessMemory.category, BusinessMemory.updated_at.desc()
+    )
+    if category:
+        query = query.filter(BusinessMemory.category == category)
+    return query.all()
+
+
+@router.get("/memory/categories", response_model=List[str])
+def list_categories(db: Session = Depends(get_db)):
+    rows = (
+        db.query(BusinessMemory.category)
+        .distinct()
+        .order_by(BusinessMemory.category)
+        .all()
+    )
+    return [r[0] for r in rows]
+
+
+@router.post("/memory", response_model=BusinessMemoryResponse)
+def create_memory(body: BusinessMemoryCreate, db: Session = Depends(get_db)):
+    memory = BusinessMemory(
+        category=body.category,
+        key=body.key,
+        value=body.value,
+        source="manual",
+    )
+    db.add(memory)
+    db.commit()
+    db.refresh(memory)
+    return memory
+
+
+@router.patch("/memory/{memory_id}", response_model=BusinessMemoryResponse)
+def update_memory(
+    memory_id: int, body: BusinessMemoryUpdate, db: Session = Depends(get_db)
+):
+    memory = db.query(BusinessMemory).filter(BusinessMemory.id == memory_id).first()
+    if not memory:
+        raise HTTPException(status_code=404, detail="Memory not found")
+    if body.category is not None:
+        memory.category = body.category
+    if body.key is not None:
+        memory.key = body.key
+    if body.value is not None:
+        memory.value = body.value
+    db.commit()
+    db.refresh(memory)
+    return memory
+
+
+@router.delete("/memory/{memory_id}")
+def delete_memory(memory_id: int, db: Session = Depends(get_db)):
+    memory = db.query(BusinessMemory).filter(BusinessMemory.id == memory_id).first()
+    if not memory:
+        raise HTTPException(status_code=404, detail="Memory not found")
+    db.delete(memory)
+    db.commit()
+    return {"ok": True}
+
+
+@router.delete("/memory")
+def reset_all_memories(db: Session = Depends(get_db)):
+    count = db.query(BusinessMemory).delete()
+    db.commit()
+    return {"ok": True, "deleted": count}

--- a/backend/app/schemas/memory.py
+++ b/backend/app/schemas/memory.py
@@ -1,0 +1,30 @@
+from typing import Optional
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class BusinessMemoryCreate(BaseModel):
+    category: str = "general"
+    key: str
+    value: str
+
+
+class BusinessMemoryUpdate(BaseModel):
+    category: Optional[str] = None
+    key: Optional[str] = None
+    value: Optional[str] = None
+
+
+class BusinessMemoryResponse(BaseModel):
+    id: int
+    business_id: Optional[int] = None
+    category: str
+    key: str
+    value: str
+    source: str
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True

--- a/backend/app/services/ai_engine.py
+++ b/backend/app/services/ai_engine.py
@@ -428,6 +428,30 @@ IMPORTANT: Only use <connect_tool> for tools that are NOT currently connected. \
 Only use <disconnect_tool> and <disconnect_confirmed> for tools that ARE currently connected. \
 Check the connection status information provided above. If a tool is already connected and \
 the owner asks to connect it, just let them know it's already set up.
+
+BUSINESS MEMORY — REMEMBER IMPORTANT DETAILS:
+
+During conversation, if the owner shares important business information that should be \
+remembered across conversations (like business hours, pricing, preferred tone, VIP clients, \
+common procedures), you can suggest saving it to business memory.
+
+When you identify something worth remembering:
+1. Briefly note what you'd like to save: "That's useful — I can remember that your business \
+hours are 9am-5pm EST so I always have it. Want me to save that?"
+2. At the very end of your message, append this hidden tag:
+<memory_save>CATEGORY:KEY:VALUE</memory_save>
+Example: <memory_save>hours:Business hours:9am-5pm EST, Monday through Friday</memory_save>
+Example: <memory_save>preferences:Communication tone:Owner prefers formal, professional tone</memory_save>
+Example: <memory_save>clients:VIP clients:Jane Smith, Mike Johnson</memory_save>
+
+Categories to use: hours, preferences, clients, services, pricing, policies, general
+
+IMPORTANT: NEVER save to memory without asking the owner first. The tag triggers a \
+confirmation card — the owner must approve before anything is stored. Only suggest saving \
+things that are genuinely reusable across conversations, not one-time details.
+
+If the "MEMORY CONTEXT" section below contains saved business memories, use that knowledge \
+naturally in your responses. You don't need to re-save things that are already in memory.
 """
 
 # Tool definition for structured workflow extraction
@@ -691,6 +715,19 @@ def parse_ai_response(raw_content: str) -> dict:
     if workflow_edit_confirmed_match:
         workflow_edit_confirmed = workflow_edit_confirmed_match.group(1).strip()
 
+    # Extract memory_save (e.g., <memory_save>hours:Business hours:9am-5pm EST</memory_save>)
+    memory_save = None
+    memory_save_match = re.search(r"<memory_save>([^:]+):([^:]+):(.+?)</memory_save>", raw_content)
+    if memory_save_match:
+        memory_save = {
+            "category": memory_save_match.group(1).strip(),
+            "key": memory_save_match.group(2).strip(),
+            "value": memory_save_match.group(3).strip(),
+        }
+
+    # Extract memory_save_confirmed
+    memory_save_confirmed = "<memory_save_confirmed>true</memory_save_confirmed>" in raw_content
+
     # Extract choices (e.g., <choices>Option A|Option B|Option C</choices>)
     choices = None
     choices_match = re.search(r"<choices>(.+?)</choices>", raw_content)
@@ -735,6 +772,9 @@ def parse_ai_response(raw_content: str) -> dict:
         clean = clean.replace(workflow_edit_confirmed_match.group(0), "")
     if choices_match:
         clean = clean.replace(choices_match.group(0), "")
+    if memory_save_match:
+        clean = clean.replace(memory_save_match.group(0), "")
+    clean = clean.replace("<memory_save_confirmed>true</memory_save_confirmed>", "")
     # Strip any [System: ...] text the AI may echo from its history
     clean = re.sub(r"\[System:.*?\]", "", clean)
     clean = clean.strip()
@@ -760,6 +800,8 @@ def parse_ai_response(raw_content: str) -> dict:
         "workflow_edit": workflow_edit,
         "workflow_edit_confirmed": workflow_edit_confirmed,
         "choices": choices,
+        "memory_save": memory_save,
+        "memory_save_confirmed": memory_save_confirmed,
     }
 
 
@@ -1255,11 +1297,62 @@ def _build_connection_status(connected_providers: Optional[List[str]] = None) ->
     return "\n".join(parts)
 
 
+def _build_memory_context(
+    business_memories: Optional[List[dict]] = None,
+    session_context: Optional[dict] = None,
+) -> str:
+    """Build labeled memory context for injection into the system prompt."""
+    parts = []
+
+    if business_memories:
+        total = len(business_memories)
+        capped = business_memories[:20]
+        lines = []
+        for mem in capped:
+            val = mem["value"]
+            if len(val) > 200:
+                val = val[:197] + "..."
+            lines.append(f"- [{mem['category']}] {mem['key']}: {val}")
+        section = "=== SAVED BUSINESS MEMORY (Tier 3 — persistent, owner-editable) ===\n" + "\n".join(lines)
+        if total > 20:
+            section += f"\n(Showing 20 most recent of {total} total memories)"
+        parts.append(section)
+
+    if session_context:
+        lines = []
+        if session_context.get("task"):
+            lines.append(f"- Current task: {session_context['task']}")
+        for pref in session_context.get("preferences", []):
+            lines.append(f"- Preference: {pref}")
+        skip_keys = {"task", "preferences"}
+        for k, v in session_context.items():
+            if k not in skip_keys:
+                lines.append(f"- {k}: {v}")
+        if lines:
+            parts.append(
+                "=== SESSION CONTEXT (Tier 2 — this conversation only) ===\n"
+                + "\n".join(lines)
+            )
+
+    if not parts:
+        return ""
+
+    return (
+        "\n\n--- MEMORY CONTEXT ---\n"
+        "Tier 2 (session) = persists across turns in this conversation.\n"
+        "Tier 3 (saved) = permanent business knowledge, owner can edit/delete via Settings > Memory.\n\n"
+        + "\n\n".join(parts)
+        + "\n--- END MEMORY CONTEXT ---"
+    )
+
+
 async def get_ai_response(
     messages: List[Dict[str, str]],
     timezone: str = "UTC",
     workflow_names: Optional[List[str]] = None,
     connected_providers: Optional[List[str]] = None,
+    business_memories: Optional[List[dict]] = None,
+    session_context: Optional[dict] = None,
 ) -> str:
     """Send messages to Claude and return the assistant's response."""
     from datetime import datetime, timezone as tz
@@ -1299,6 +1392,11 @@ async def get_ai_response(
     else:
         system += "\n\nThe owner has no saved processes yet. If they ask to see their workflows, " \
                   "still use <workflow_list>true</workflow_list> — the system will show an empty state."
+
+    # Inject memory context (Tier 2 session + Tier 3 saved business memories)
+    memory_section = _build_memory_context(business_memories, session_context)
+    if memory_section:
+        system += memory_section
 
     response = await client.messages.create(
         model=CLAUDE_MODEL,

--- a/docs/phase-18d-memory.md
+++ b/docs/phase-18d-memory.md
@@ -1,0 +1,88 @@
+# Phase 18D: Transparent State & Business Memory
+
+## Overview
+
+Three-tier memory system that lets AImplify remember business context across conversations with full owner control.
+
+## Memory Tiers
+
+| Tier | Scope | Storage | Lifecycle |
+|------|-------|---------|-----------|
+| 1 — Transient | Single exchange | Signal tags + metadata | Auto-cleared after response |
+| 2 — Session | Conversation | `conversations.session_context` (JSON) | Per-conversation, cleared on end |
+| 3 — Saved | Cross-session | `business_memories` table | Persistent, owner-editable |
+
+## API Endpoints
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| GET | `/api/memory` | List memories (optional `?category=` filter) |
+| POST | `/api/memory` | Create memory manually |
+| PATCH | `/api/memory/{id}` | Update a memory |
+| DELETE | `/api/memory/{id}` | Delete a memory |
+| DELETE | `/api/memory` | Reset all memories |
+| GET | `/api/memory/categories` | List distinct categories |
+
+## Signal Tags
+
+| Tag | Direction | Purpose |
+|-----|-----------|---------|
+| `<memory_save>CATEGORY:KEY:VALUE</memory_save>` | AI -> Backend | Propose saving to memory |
+| `<memory_save_confirmed>true</memory_save_confirmed>` | AI -> Backend | Owner confirmed save |
+
+## Categories
+
+hours, preferences, clients, services, pricing, policies, general
+
+## UI
+
+- **Memory page** (`/settings/memory`): View, add, edit, delete memories. Grouped by category.
+- **Chat cards**: Purple confirmation card when AI suggests saving, green/red result banner.
+- **Sidebar**: "Memory" nav item with Brain icon.
+
+## Prompt Injection
+
+Saved memories are injected at the end of Claude's system prompt in a labeled section:
+```
+--- MEMORY CONTEXT ---
+=== SAVED BUSINESS MEMORY (Tier 3 — persistent, owner-editable) ===
+- [hours] Business hours: 9am-5pm EST, Monday through Friday
+- [clients] VIP clients: Jane Smith, Mike Johnson
+=== SESSION CONTEXT (Tier 2 — this conversation only) ===
+- Current task: setting up a workflow
+--- END MEMORY CONTEXT ---
+```
+
+Capped at 20 memories, values truncated to 200 chars to prevent prompt bloat.
+
+## How to Test
+
+1. **Memory page**: Go to `/settings/memory` — should show empty state
+2. **Manual add**: Click "Add Memory" — fill in category, label, value — verify card appears
+3. **Edit**: Click pencil icon — modify value — verify update
+4. **Delete**: Click trash icon — confirm — verify removal
+5. **Chat save flow**: Start a conversation, say "My business hours are 9am-5pm Monday through Friday"
+   - Claude should suggest saving — purple card appears
+   - Reply "yes" — green "Saved!" banner appears
+6. **Memory page confirms**: Navigate to `/settings/memory` — entry should appear with "via chat" badge
+7. **Cross-conversation recall**: Start NEW conversation — ask "What are my business hours?" — Claude should know
+8. **Reset**: Click "Reset All Memories" — confirm — all entries removed
+
+## Files Changed
+
+### New Files
+- `backend/app/models/memory.py` — BusinessMemory model
+- `backend/app/schemas/memory.py` — Pydantic schemas
+- `backend/app/routers/memory.py` — CRUD API endpoints
+- `frontend/src/app/settings/memory/page.tsx` — Memory management page
+- `docs/phase-18d-memory.md` — This file
+
+### Modified Files
+- `backend/app/models/conversation.py` — Added `session_context` JSON column
+- `backend/app/models/__init__.py` — Registered BusinessMemory
+- `backend/app/database.py` — Added migration + model import
+- `backend/app/main.py` — Mounted memory router
+- `backend/app/services/ai_engine.py` — Memory context builder, system prompt, signal tag parsing, get_ai_response params
+- `backend/app/routers/chat.py` — Memory query/injection, signal handlers, history builder, session context
+- `frontend/src/components/Sidebar.tsx` — Added Memory nav item
+- `frontend/src/components/MessageBubble.tsx` — Added memory_save_request/result card types

--- a/frontend/src/app/settings/memory/page.tsx
+++ b/frontend/src/app/settings/memory/page.tsx
@@ -1,0 +1,431 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { api } from "@/lib/api";
+import { timeAgo } from "@/lib/workflow-utils";
+
+interface BusinessMemory {
+  id: number;
+  business_id: number | null;
+  category: string;
+  key: string;
+  value: string;
+  source: string;
+  created_at: string;
+  updated_at: string;
+}
+
+const CATEGORIES = [
+  "general",
+  "hours",
+  "preferences",
+  "clients",
+  "services",
+  "pricing",
+  "policies",
+];
+
+export default function MemoryPage() {
+  const [memories, setMemories] = useState<BusinessMemory[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
+  const [confirmResetAll, setConfirmResetAll] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  // Add form state
+  const [newCategory, setNewCategory] = useState("general");
+  const [newKey, setNewKey] = useState("");
+  const [newValue, setNewValue] = useState("");
+
+  // Edit form state
+  const [editCategory, setEditCategory] = useState("");
+  const [editKey, setEditKey] = useState("");
+  const [editValue, setEditValue] = useState("");
+
+  useEffect(() => {
+    fetchMemories();
+  }, []);
+
+  async function fetchMemories() {
+    try {
+      const data = await api.get<BusinessMemory[]>("/api/memory");
+      setMemories(data);
+    } catch {
+      // Backend might not be reachable
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleAdd() {
+    if (!newKey.trim() || !newValue.trim()) return;
+    setSaving(true);
+    try {
+      await api.post("/api/memory", {
+        category: newCategory,
+        key: newKey.trim(),
+        value: newValue.trim(),
+      });
+      setNewCategory("general");
+      setNewKey("");
+      setNewValue("");
+      setShowAddForm(false);
+      await fetchMemories();
+    } catch {
+      // Best effort
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function startEdit(mem: BusinessMemory) {
+    setEditingId(mem.id);
+    setEditCategory(mem.category);
+    setEditKey(mem.key);
+    setEditValue(mem.value);
+  }
+
+  async function handleSaveEdit() {
+    if (!editingId || !editKey.trim() || !editValue.trim()) return;
+    setSaving(true);
+    try {
+      await api.patch(`/api/memory/${editingId}`, {
+        category: editCategory,
+        key: editKey.trim(),
+        value: editValue.trim(),
+      });
+      setEditingId(null);
+      await fetchMemories();
+    } catch {
+      // Best effort
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete(id: number) {
+    try {
+      await api.delete(`/api/memory/${id}`);
+      setConfirmDeleteId(null);
+      await fetchMemories();
+    } catch {
+      // Best effort
+    }
+  }
+
+  async function handleResetAll() {
+    try {
+      await api.delete("/api/memory");
+      setConfirmResetAll(false);
+      await fetchMemories();
+    } catch {
+      // Best effort
+    }
+  }
+
+  // Group memories by category
+  const grouped: Record<string, BusinessMemory[]> = {};
+  for (const mem of memories) {
+    if (!grouped[mem.category]) grouped[mem.category] = [];
+    grouped[mem.category].push(mem);
+  }
+  const categories = Object.keys(grouped).sort();
+
+  return (
+    <div className="p-6 max-w-2xl">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-semibold text-stone-900">
+            Business Memory
+          </h1>
+          <p className="text-sm text-stone-500 mt-1">
+            Things AImplify remembers about your business. You can edit or
+            remove anything.
+          </p>
+        </div>
+        {!showAddForm && (
+          <button
+            onClick={() => setShowAddForm(true)}
+            className="px-4 py-2 text-sm rounded-lg bg-primary text-white font-semibold hover:bg-primary-hover transition-colors"
+          >
+            Add Memory
+          </button>
+        )}
+      </div>
+
+      {/* Add form */}
+      {showAddForm && (
+        <div className="mt-4 border border-stone-200 rounded-xl p-5 space-y-3">
+          <h3 className="text-sm font-semibold text-stone-900">
+            Add New Memory
+          </h3>
+          <div>
+            <label className="block text-xs font-medium text-stone-500 mb-1">
+              Category
+            </label>
+            <select
+              value={newCategory}
+              onChange={(e) => setNewCategory(e.target.value)}
+              className="w-full border border-stone-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-primary/50 focus:border-primary outline-none"
+            >
+              {CATEGORIES.map((c) => (
+                <option key={c} value={c}>
+                  {c.charAt(0).toUpperCase() + c.slice(1)}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-stone-500 mb-1">
+              Label
+            </label>
+            <input
+              type="text"
+              value={newKey}
+              onChange={(e) => setNewKey(e.target.value)}
+              placeholder='e.g., "Business hours"'
+              className="w-full border border-stone-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-primary/50 focus:border-primary outline-none"
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-stone-500 mb-1">
+              Value
+            </label>
+            <textarea
+              value={newValue}
+              onChange={(e) => setNewValue(e.target.value)}
+              placeholder='e.g., "9am-5pm EST, Monday through Friday"'
+              rows={2}
+              className="w-full border border-stone-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-primary/50 focus:border-primary outline-none resize-none"
+            />
+          </div>
+          <div className="flex gap-2">
+            <button
+              onClick={handleAdd}
+              disabled={saving || !newKey.trim() || !newValue.trim()}
+              className="px-4 py-2 text-sm rounded-lg bg-primary text-white font-semibold hover:bg-primary-hover transition-colors disabled:opacity-50"
+            >
+              {saving ? "Saving..." : "Save"}
+            </button>
+            <button
+              onClick={() => {
+                setShowAddForm(false);
+                setNewKey("");
+                setNewValue("");
+              }}
+              className="px-4 py-2 text-sm rounded-lg border border-stone-200 text-stone-600 hover:bg-stone-50 transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Loading state */}
+      {loading && (
+        <p className="mt-6 text-sm text-stone-400">Loading memories...</p>
+      )}
+
+      {/* Empty state */}
+      {!loading && memories.length === 0 && (
+        <div className="mt-6 border border-dashed border-stone-300 rounded-xl p-8 text-center">
+          <p className="text-sm text-stone-500">
+            No saved memories yet. As you chat with AImplify, it may suggest
+            remembering important details about your business. You can also add
+            them manually here.
+          </p>
+        </div>
+      )}
+
+      {/* Grouped memory list */}
+      {categories.length > 0 && (
+        <div className="mt-6 space-y-6">
+          {categories.map((cat) => (
+            <div key={cat}>
+              <h2 className="text-xs font-semibold text-stone-400 uppercase tracking-wider mb-2">
+                {cat}
+              </h2>
+              <div className="space-y-2">
+                {grouped[cat].map((mem) => (
+                  <div
+                    key={mem.id}
+                    className="border border-stone-200 rounded-xl p-4"
+                  >
+                    {editingId === mem.id ? (
+                      /* Edit mode */
+                      <div className="space-y-3">
+                        <select
+                          value={editCategory}
+                          onChange={(e) => setEditCategory(e.target.value)}
+                          className="w-full border border-stone-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-primary/50 focus:border-primary outline-none"
+                        >
+                          {CATEGORIES.map((c) => (
+                            <option key={c} value={c}>
+                              {c.charAt(0).toUpperCase() + c.slice(1)}
+                            </option>
+                          ))}
+                        </select>
+                        <input
+                          type="text"
+                          value={editKey}
+                          onChange={(e) => setEditKey(e.target.value)}
+                          className="w-full border border-stone-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-primary/50 focus:border-primary outline-none"
+                        />
+                        <textarea
+                          value={editValue}
+                          onChange={(e) => setEditValue(e.target.value)}
+                          rows={2}
+                          className="w-full border border-stone-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-primary/50 focus:border-primary outline-none resize-none"
+                        />
+                        <div className="flex gap-2">
+                          <button
+                            onClick={handleSaveEdit}
+                            disabled={
+                              saving || !editKey.trim() || !editValue.trim()
+                            }
+                            className="px-3 py-1.5 text-sm rounded-lg bg-primary text-white font-semibold hover:bg-primary-hover transition-colors disabled:opacity-50"
+                          >
+                            {saving ? "Saving..." : "Save"}
+                          </button>
+                          <button
+                            onClick={() => setEditingId(null)}
+                            className="px-3 py-1.5 text-sm rounded-lg border border-stone-200 text-stone-600 hover:bg-stone-50 transition-colors"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </div>
+                    ) : confirmDeleteId === mem.id ? (
+                      /* Delete confirmation */
+                      <div className="flex items-center justify-between">
+                        <p className="text-sm text-red-600">
+                          Delete &ldquo;{mem.key}&rdquo;?
+                        </p>
+                        <div className="flex gap-2">
+                          <button
+                            onClick={() => handleDelete(mem.id)}
+                            className="px-3 py-1.5 text-xs rounded-lg bg-red-600 text-white font-semibold hover:bg-red-700 transition-colors"
+                          >
+                            Delete
+                          </button>
+                          <button
+                            onClick={() => setConfirmDeleteId(null)}
+                            className="px-3 py-1.5 text-xs rounded-lg border border-stone-200 text-stone-600 hover:bg-stone-50 transition-colors"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                      /* Display mode */
+                      <div>
+                        <div className="flex items-start justify-between">
+                          <div className="flex-1 min-w-0">
+                            <p className="text-sm font-medium text-stone-900">
+                              {mem.key}
+                            </p>
+                            <p className="text-sm text-stone-600 mt-0.5">
+                              {mem.value}
+                            </p>
+                          </div>
+                          <div className="flex items-center gap-1 ml-3 shrink-0">
+                            <button
+                              onClick={() => startEdit(mem)}
+                              className="p-1.5 text-stone-400 hover:text-stone-600 hover:bg-stone-100 rounded-lg transition-colors"
+                              title="Edit"
+                            >
+                              <svg
+                                className="w-3.5 h-3.5"
+                                fill="none"
+                                stroke="currentColor"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  strokeWidth={2}
+                                  d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
+                                />
+                              </svg>
+                            </button>
+                            <button
+                              onClick={() => setConfirmDeleteId(mem.id)}
+                              className="p-1.5 text-stone-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-colors"
+                              title="Delete"
+                            >
+                              <svg
+                                className="w-3.5 h-3.5"
+                                fill="none"
+                                stroke="currentColor"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  strokeWidth={2}
+                                  d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                        </div>
+                        <div className="flex items-center gap-2 mt-2">
+                          <span
+                            className={`text-xs font-medium px-2 py-0.5 rounded-full ${
+                              mem.source === "chat"
+                                ? "bg-amber-100 text-amber-700"
+                                : "bg-stone-100 text-stone-500"
+                            }`}
+                          >
+                            {mem.source === "chat" ? "via chat" : "manual"}
+                          </span>
+                          <span className="text-xs text-stone-400">
+                            {timeAgo(mem.updated_at)}
+                          </span>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Reset all */}
+      {memories.length > 0 && (
+        <div className="mt-8 pt-6 border-t border-stone-200">
+          {confirmResetAll ? (
+            <div className="flex items-center gap-3">
+              <p className="text-sm text-red-600">
+                This will delete all {memories.length} memories. Are you sure?
+              </p>
+              <button
+                onClick={handleResetAll}
+                className="px-3 py-1.5 text-xs rounded-lg bg-red-600 text-white font-semibold hover:bg-red-700 transition-colors"
+              >
+                Yes, reset all
+              </button>
+              <button
+                onClick={() => setConfirmResetAll(false)}
+                className="px-3 py-1.5 text-xs rounded-lg border border-stone-200 text-stone-600 hover:bg-stone-50 transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          ) : (
+            <button
+              onClick={() => setConfirmResetAll(true)}
+              className="px-4 py-2 text-sm rounded-lg border border-red-200 text-red-600 hover:bg-red-50 transition-colors"
+            >
+              Reset All Memories
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -63,6 +63,10 @@ interface MessageMetadata {
   next_run_at?: string;
   current_schedule?: string;
   choices?: string[];
+  memory_category?: string;
+  memory_key?: string;
+  memory_value?: string;
+  pending_memory?: { category: string; key: string; value: string };
 }
 
 interface MessageBubbleProps {
@@ -440,6 +444,55 @@ export function MessageBubble({ role, content, metadata, onConnectTool, onChoice
           ) : (
             <div className="bg-red-50 border border-red-200 rounded-xl px-4 py-3 text-sm text-red-700 font-medium">
               Failed to disconnect {info.name}: {metadata.error || "Unknown error"}
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // Memory save request — show confirmation card
+  if (metadata?.message_type === "memory_save_request") {
+    return (
+      <div className="flex justify-start">
+        <div className="max-w-[75%] space-y-3">
+          <div className="bg-stone-100 rounded-2xl px-4 py-3 text-sm leading-relaxed text-stone-800 rounded-bl-md">
+            {content}
+          </div>
+          <div className="bg-purple-50 border border-purple-200 rounded-xl px-4 py-3 text-sm text-purple-700">
+            <div className="font-medium flex items-center gap-1.5">
+              <span className="text-base">&#128190;</span> Save to Business Memory
+            </div>
+            <div className="mt-1.5 text-purple-600">
+              <span className="font-medium">{metadata.memory_key}</span>: {metadata.memory_value}
+            </div>
+            <div className="text-xs text-purple-400 mt-1">
+              Category: {metadata.memory_category}
+            </div>
+            <div className="mt-2 text-xs text-purple-500">
+              Reply <span className="font-semibold">&ldquo;yes&rdquo;</span> to save or <span className="font-semibold">&ldquo;no&rdquo;</span> to skip
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Memory save result — show success/error banner
+  if (metadata?.message_type === "memory_save_result") {
+    return (
+      <div className="flex justify-start">
+        <div className="max-w-[75%] space-y-3">
+          <div className="bg-stone-100 rounded-2xl px-4 py-3 text-sm leading-relaxed text-stone-800 rounded-bl-md">
+            {content}
+          </div>
+          {metadata.success ? (
+            <div className="bg-green-50 border border-green-200 rounded-xl px-4 py-3 text-sm text-green-700 font-medium">
+              Saved &ldquo;{metadata.memory_key}&rdquo; to business memory!
+            </div>
+          ) : (
+            <div className="bg-red-50 border border-red-200 rounded-xl px-4 py-3 text-sm text-red-700 font-medium">
+              Failed to save to memory
             </div>
           )}
         </div>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Home, MessageSquare, LayoutDashboard, Zap, Settings, type LucideIcon } from "lucide-react";
+import { Home, MessageSquare, LayoutDashboard, Zap, Brain, Settings, type LucideIcon } from "lucide-react";
 
 interface NavItem {
   href: string;
@@ -16,6 +16,7 @@ const navItems: NavItem[] = [
   { href: "/chat", label: "Chat", icon: MessageSquare },
   { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard, exact: true },
   { href: "/dashboard/workflows", label: "Workflows", icon: Zap },
+  { href: "/settings/memory", label: "Memory", icon: Brain },
   { href: "/settings/integrations", label: "Settings", icon: Settings },
 ];
 


### PR DESCRIPTION
## Summary
- Adds three-tier memory system: transient turn context (existing), session context (per-conversation), and saved business memory (persistent, owner-editable)
- New `/settings/memory` page for viewing, adding, editing, and deleting business memories
- Claude suggests saving important business details via `<memory_save>` signal tag with owner confirmation flow
- Saved memories injected into Claude's system prompt with tier labels, capped at 20 entries to prevent bloat

## Test plan
### Memory settings page
- [ ] Navigate to `/settings/memory` — should show empty state
- [ ] Click "Add Memory" — fill in category "hours", label "Business hours", value "9am-5pm EST Mon-Fri" — verify card appears
- [ ] Click pencil icon to edit — modify the value — verify update persists
- [ ] Click trash icon to delete — confirm — verify removal
- [ ] Add 3+ memories — verify they group by category with section headers
- [ ] Click "Reset All Memories" — confirm — verify all entries removed

### Chat memory save flow
- [ ] Go to `/chat` — start new conversation — type "My VIP clients are Jane Smith and Mike Johnson"
- [ ] Claude should suggest saving — purple confirmation card appears with "Reply yes to save"
- [ ] Reply "yes" — green "Saved!" banner appears
- [ ] Navigate to `/settings/memory` — "VIP clients" entry visible with "via chat" badge

### Cross-conversation recall
- [ ] Start a NEW conversation — type "Who are my VIP clients?"
- [ ] Claude should answer from saved memory

### Sidebar
- [ ] "Memory" nav item appears between Workflows and Settings with Brain icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)