### PR TITLE
Phase 17B: State machine field collection for immediate actions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,12 +23,21 @@ AI operations layer for medspas. Owners describe how their business works in pla
 - DELETE /api/conversations/{id} nulls out Workflow.conversation_id FK before cascade-deleting messages
 
 ## Signal Tag System
-- AI embeds hidden XML tags in responses (e.g., `<action_request>send_email</action_request>`) to trigger backend actions
-- Tags are parsed in `parse_ai_response()` in `ai_engine.py`, stripped from user-visible content
-- Current tags: `action_request`, `action_confirmed`, `workflow_ready`, `workflow_confirmed`, `workflow_manage`, `workflow_manage_confirmed`, `workflow_list`, `workflow_activity`, `workflow_status`, `workflow_run`, `workflow_run_confirmed`, `workflow_schedule`, `workflow_schedule_confirmed`, `workflow_edit`, `workflow_edit_confirmed`, `connect_tool`, `disconnect_tool`, `disconnect_confirmed`, `choices`
-- New action types must be added to: `ACTION_EXTRACTION_TOOLS` (ai_engine.py), `ACTION_PROVIDER` map (chat.py), `_execute_chat_action` (chat.py), `ACTION_LABELS` (MessageBubble.tsx)
-- Handler ordering in chat.py matters: workflow query handlers (list/status/activity/run) must run BEFORE `_detect_action_gathering` safety net to prevent false positives on words like "schedule" in workflow descriptions
+- AI embeds hidden XML tags in responses for **workflow** operations — tags are parsed in `parse_ai_response()` in `ai_engine.py`, stripped from user-visible content
+- Current workflow tags: `workflow_ready`, `workflow_confirmed`, `workflow_manage`, `workflow_manage_confirmed`, `workflow_list`, `workflow_activity`, `workflow_status`, `workflow_run`, `workflow_run_confirmed`, `workflow_schedule`, `workflow_schedule_confirmed`, `workflow_edit`, `workflow_edit_confirmed`, `connect_tool`, `disconnect_tool`, `disconnect_confirmed`, `choices`
+- **Immediate actions** (send_email, create_event, etc.) do NOT use signal tags — they use the state machine (see below)
 - When adding new AI capabilities via signal tags, the system prompt must assertively state the AI HAS the capability (like connection status does) — otherwise the AI may claim it can't do it
+
+## Action State Machine (Phase 17B)
+- Immediate actions use a backend state machine instead of AI-driven signal tags
+- **Intent detection**: AI calls `register_intent` tool (defined in `REGISTER_INTENT_TOOL` in ai_engine.py) with `action_type` — replaces `<action_request>` tags
+- **Form state**: `ActionFormState` model tracks fields per conversation — status flows: `collecting` → `ready` → `executed` (or `cancelled`)
+- **Field schemas**: `REQUIRED_FIELD_SCHEMAS` in `form_state.py` defines required/optional fields per action type
+- **Field collection**: Backend extracts fields from conversation each turn, tells AI which field to ask about next via system prompt injection (`build_form_context()`)
+- **Confirmation**: Card shown automatically when all required fields are non-null — AI never decides this
+- **Execution**: Backend detects affirmative user message (`_is_affirmative()`) when form status is "ready" and executes directly
+- **Auto-execute actions**: `list_events` and `check_availability` bypass the form state — they execute immediately when intent is detected
+- New action types must be added to: `REQUIRED_FIELD_SCHEMAS` (form_state.py), `REGISTER_INTENT_TOOL` enum (ai_engine.py), `ACTION_EXTRACTION_TOOLS` (ai_engine.py), `ACTION_PROVIDER` map (chat.py), `_execute_chat_action` (chat.py), `ACTION_LABELS` (MessageBubble.tsx)
 
 ## Choice Buttons
 - `<choices>Option A|Option B|Option C</choices>` renders clickable buttons in the chat UI
@@ -49,7 +58,7 @@ AI operations layer for medspas. Owners describe how their business works in pla
 - User's timezone is injected from `request.timezone` into `trigger_config.timezone` during workflow_confirmed handling
 - Scheduled runs inject owner's Gmail address into context via `users.getProfile` API so "send to yourself" resolves
 - `next_run_at` is stored as UTC; frontend must append `Z` to ISO strings before `new Date()` parsing
-- Content-based fallbacks exist for `workflow_schedule` and `action_request` tags when the AI forgets to emit them
+- Content-based fallback exists for `workflow_schedule` tags when the AI forgets to emit them
 - `_detect_tool_from_user_intent()` pre-flight check scans user messages for tool keywords and short-circuits with connect card before calling AI
 - Google OAuth tokens expire after 7 days in "Testing" mode; `google_auth.py` catches `invalid_grant` and marks integration as "expired"
 
@@ -96,10 +105,9 @@ AI operations layer for medspas. Owners describe how their business works in pla
 - `EVENT_PARAMS_TOOL` examples use timezone offset format (`-04:00`), NOT `Z`/UTC — the AI copies the example format
 - `gmail.py` validates and cleans email addresses before sending — extracts valid email from `"Name <email>"` format, rejects empty/invalid values with clear error messages
 
-## Action Detection Guards
-- `_detect_action_from_content` only checks confirmation phrases in the last ~200 chars and skips if the response ends with an info-gathering question (what/who/which/where + ?)
-- Before the `action_request` handler, if the response ends with an info-gathering question, `action_request_type` is nulled — prevents premature confirmation cards from both explicit tags and content-based fallbacks
+## Action Detection
 - When adding new AI capabilities, update `PROVIDER_DISPLAY` capabilities string — the connection status assertively tells the AI what it CAN do, and omissions cause the AI to claim it can't
+- The `_detect_tool_from_user_intent()` pre-flight check still runs before the AI call to catch disconnected-tool scenarios early
 
 ## Tool Connection System
 - Connection status is dynamic in the system prompt — built by `_build_connection_status()` from actual DB state

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -29,7 +29,7 @@ _MIGRATIONS = [
 
 def init_db():
     """Create all tables if they don't exist, then run migrations."""
-    from app.models import user, business, conversation, workflow, activity_log, integration  # noqa: F401
+    from app.models import user, business, conversation, workflow, activity_log, integration, action_form  # noqa: F401
     Base.metadata.create_all(bind=engine)
 
     # Run pending migrations (skip if column already exists)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -4,6 +4,7 @@ from app.models.conversation import Conversation, Message
 from app.models.workflow import Workflow, WorkflowStep
 from app.models.activity_log import ActivityLog
 from app.models.integration import Integration
+from app.models.action_form import ActionFormState
 
 __all__ = [
     "User",
@@ -14,4 +15,5 @@ __all__ = [
     "WorkflowStep",
     "ActivityLog",
     "Integration",
+    "ActionFormState",
 ]

--- a/backend/app/models/action_form.py
+++ b/backend/app/models/action_form.py
@@ -1,0 +1,25 @@
+from datetime import datetime, timezone
+
+from sqlalchemy import String, Integer, ForeignKey, JSON
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class ActionFormState(Base):
+    __tablename__ = "action_form_states"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    conversation_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("conversations.id"), index=True
+    )
+    action_type: Mapped[str] = mapped_column(String(50))
+    fields: Mapped[dict] = mapped_column(JSON, default=dict)
+    status: Mapped[str] = mapped_column(String(20), default="collecting")
+    created_at: Mapped[datetime] = mapped_column(
+        default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )

--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -30,6 +30,18 @@ from app.services.workflow_engine import create_workflow_from_draft
 from app.services.workflow_runner import run_workflow
 from app.services.gmail import send_email
 from app.services.calendar import create_event, update_event, check_availability, list_upcoming_events
+from app.services.form_state import (
+    get_active_form,
+    create_form_state,
+    update_form_fields,
+    check_completion,
+    get_next_missing_field,
+    build_form_context,
+    is_auto_execute,
+    is_skip_confirmation,
+    REQUIRED_FIELD_SCHEMAS,
+)
+from app.models.action_form import ActionFormState
 
 router = APIRouter(prefix="/api")
 
@@ -99,12 +111,12 @@ async def chat(request: ChatRequest, db: Session = Depends(get_db)):
                     error = details.get("error", "Unknown error")
                     content += f"\n\n[System: Action '{action_type}' failed. Error: {error}]"
             elif msg_type == "action_request":
-                # Let Claude know a confirmation card was shown so it emits
-                # <action_confirmed> (not another <action_request>) when the user says "yes"
                 action_type = m.metadata_json.get("action_type", "")
-                content += f"\n\n[System: A confirmation card for '{action_type}' is being shown to the user. " \
-                           "When they confirm, respond with a short acknowledgment and use <action_confirmed> — " \
-                           "do NOT re-summarize or show another <action_request>.]"
+                content += (
+                    f"\n\n[System: A confirmation card for '{action_type}' is being shown to the user. "
+                    "If the user says yes, the system executes automatically. "
+                    "If they want changes, help them adjust.]"
+                )
             elif msg_type == "connect_tool":
                 provider = m.metadata_json.get("provider", "")
                 content += f"\n\n[System: A 'Connect' button for '{provider}' is being shown to the user. " \
@@ -223,9 +235,216 @@ async def chat(request: ChatRequest, db: Session = Depends(get_db)):
             message=MessageResponse.model_validate(assistant_message),
         )
 
-    raw_content = await get_ai_response(
+    # ── Form state machine: check for active action form ────────────────
+    # Map action types to the provider they require
+    ACTION_PROVIDER = {
+        "send_email": "gmail",
+        "create_event": "google_calendar",
+        "update_event": "google_calendar",
+        "check_availability": "google_calendar",
+        "list_events": "google_calendar",
+    }
+
+    active_form = get_active_form(db, conversation.id)
+    form_ctx = None  # system prompt addendum for field collection
+    include_intent = True  # whether to include register_intent tool
+
+    if active_form and active_form.status == "ready":
+        # User is responding to a confirmation card
+        if _is_affirmative(request.message):
+            # Execute the action
+            exec_meta = {
+                "action_type": active_form.action_type,
+                "action_params": active_form.fields or {},
+            }
+            result = await _execute_chat_action(
+                db, exec_meta, conversation_id=conversation.id
+            )
+            active_form.status = "executed"
+            db.commit()
+
+            # Let AI produce a short acknowledgment
+            ack_context = (
+                f"\n\n[System: The {active_form.action_type} action was just executed "
+                f"{'successfully' if result['status'] == 'success' else 'with an error'}. "
+                "Say something short like 'Done!' or 'On it!' — the system shows the result card.]"
+            )
+            raw_content, _ = await get_ai_response(
+                messages, timezone=tz, workflow_names=wf_names,
+                connected_providers=connected_providers,
+                form_context=ack_context,
+                include_intent_tool=False,
+            )
+            signals = parse_ai_response(raw_content)
+            clean_content = signals["clean_content"]
+            metadata = {
+                "message_type": "action_result",
+                "action_type": active_form.action_type,
+                "success": result["status"] == "success",
+                "details": result.get("details", {}),
+            }
+
+            # Skip the rest of signal processing — go straight to save
+            assistant_message = Message(
+                conversation_id=conversation.id,
+                role="assistant",
+                content=clean_content,
+                metadata_json=metadata,
+            )
+            db.add(assistant_message)
+            if conversation.title == "New conversation":
+                conversation.title = request.message[:80]
+            db.commit()
+            db.refresh(assistant_message)
+            return ChatResponse(
+                conversation_id=conversation.id,
+                message=MessageResponse.model_validate(assistant_message),
+            )
+
+        elif _is_negative(request.message):
+            active_form.status = "cancelled"
+            db.commit()
+            # Fall through to normal AI call
+
+        else:
+            # User is correcting a field — go back to collecting
+            active_form.status = "collecting"
+            db.commit()
+            # Re-extract fields below
+            active_form = get_active_form(db, conversation.id)
+
+    if active_form and active_form.status == "collecting":
+        # Extract latest field values from the full conversation
+        params = await extract_action_from_conversation(
+            messages, active_form.action_type, timezone=tz
+        )
+        if params:
+            update_form_fields(db, active_form, params)
+            db.refresh(active_form)
+
+        if check_completion(active_form):
+            # Check provider connection before proceeding
+            required_provider = ACTION_PROVIDER.get(active_form.action_type)
+            if required_provider and required_provider not in connected_providers:
+                provider_name = "Gmail" if required_provider == "gmail" else "Google Calendar"
+                active_form.status = "cancelled"
+                db.commit()
+                clean_content = (
+                    f"To do that, we'll need to connect your {provider_name} first. "
+                    "Click below to get that set up — it only takes a moment!"
+                )
+                metadata = {
+                    "message_type": "connect_tool",
+                    "provider": required_provider,
+                }
+                assistant_message = Message(
+                    conversation_id=conversation.id,
+                    role="assistant",
+                    content=clean_content,
+                    metadata_json=metadata,
+                )
+                db.add(assistant_message)
+                if conversation.title == "New conversation":
+                    conversation.title = request.message[:80]
+                db.commit()
+                db.refresh(assistant_message)
+                return ChatResponse(
+                    conversation_id=conversation.id,
+                    message=MessageResponse.model_validate(assistant_message),
+                )
+
+            if is_skip_confirmation(active_form.action_type):
+                # Execute immediately — no confirmation card (e.g., check_availability)
+                active_form.status = "executed"
+                db.commit()
+                exec_meta = {
+                    "action_type": active_form.action_type,
+                    "action_params": active_form.fields or {},
+                }
+                result = await _execute_chat_action(
+                    db, exec_meta, conversation_id=conversation.id
+                )
+                # Let AI acknowledge the result
+                ack_context = (
+                    f"\n\n[System: The {active_form.action_type} action was just executed "
+                    f"{'successfully' if result['status'] == 'success' else 'with an error'}. "
+                    "Respond naturally to the result.]"
+                )
+                raw_content, _ = await get_ai_response(
+                    messages, timezone=tz, workflow_names=wf_names,
+                    connected_providers=connected_providers,
+                    form_context=ack_context,
+                    include_intent_tool=False,
+                )
+                signals = parse_ai_response(raw_content)
+                clean_content = signals["clean_content"]
+                metadata = {
+                    "message_type": "action_result",
+                    "action_type": active_form.action_type,
+                    "success": result["status"] == "success",
+                    "details": result.get("details", {}),
+                }
+                assistant_message = Message(
+                    conversation_id=conversation.id,
+                    role="assistant",
+                    content=clean_content,
+                    metadata_json=metadata,
+                )
+                db.add(assistant_message)
+                if conversation.title == "New conversation":
+                    conversation.title = request.message[:80]
+                db.commit()
+                db.refresh(assistant_message)
+                return ChatResponse(
+                    conversation_id=conversation.id,
+                    message=MessageResponse.model_validate(assistant_message),
+                )
+
+            # All required fields collected — show confirmation card
+            active_form.status = "ready"
+            db.commit()
+
+            # Let AI write a brief confirmation summary
+            confirm_ctx = build_form_context(active_form)
+            raw_content, _ = await get_ai_response(
+                messages, timezone=tz, workflow_names=wf_names,
+                connected_providers=connected_providers,
+                form_context=confirm_ctx,
+                include_intent_tool=False,
+            )
+            signals = parse_ai_response(raw_content)
+            clean_content = signals["clean_content"]
+            metadata = {
+                "message_type": "action_request",
+                "action_type": active_form.action_type,
+                "action_params": active_form.fields or {},
+            }
+
+            assistant_message = Message(
+                conversation_id=conversation.id,
+                role="assistant",
+                content=clean_content,
+                metadata_json=metadata,
+            )
+            db.add(assistant_message)
+            if conversation.title == "New conversation":
+                conversation.title = request.message[:80]
+            db.commit()
+            db.refresh(assistant_message)
+            return ChatResponse(
+                conversation_id=conversation.id,
+                message=MessageResponse.model_validate(assistant_message),
+            )
+
+        # Still missing fields — inject context for AI
+        form_ctx = build_form_context(active_form)
+        include_intent = False  # Don't re-trigger intent while collecting
+
+    raw_content, detected_action = await get_ai_response(
         messages, timezone=tz, workflow_names=wf_names,
         connected_providers=connected_providers,
+        form_context=form_ctx,
+        include_intent_tool=include_intent,
     )
     signals = parse_ai_response(raw_content)
     clean_content = signals["clean_content"]
@@ -707,59 +926,13 @@ async def chat(request: ChatRequest, db: Session = Depends(get_db)):
                 "error": "Could not find that workflow.",
             }
 
-    # Detect action request — from tag or from response content as fallback.
-    # IMPORTANT: Skip content-based detection if workflow signals are present —
-    # workflow summaries that mention "email" or "calendar" must not be hijacked
-    # by the action detection fallback.
-    if metadata or signals["workflow_ready"] or signals["workflow_confirmed"]:
-        action_request_type = signals["action_request"]  # Only explicit tag, no fallback
-    else:
-        action_request_type = signals["action_request"] or _detect_action_from_content(clean_content)
-
-    # Map action types to the provider they require
-    ACTION_PROVIDER = {
-        "send_email": "gmail",
-        "create_event": "google_calendar",
-        "update_event": "google_calendar",
-        "check_availability": "google_calendar",
-        "list_events": "google_calendar",
-    }
-
-    # Safety net: if the AI is gathering fields for a disconnected tool
-    # (asking for subject, time, etc. without emitting a connect_tool tag),
-    # intercept and show a connect card instead.
-    if not action_request_type and not signals.get("connect_tool") and not metadata:
-        gathering_action = _detect_action_gathering(clean_content)
-        if gathering_action:
-            required_provider = ACTION_PROVIDER.get(gathering_action)
-            if required_provider and required_provider not in connected_providers:
-                provider_name = "Gmail" if required_provider == "gmail" else "Google Calendar"
-                clean_content = (
-                    f"To do that, we'll need to connect your {provider_name} first. "
-                    "Click below to get that set up — it only takes a moment!"
-                )
-                metadata = {
-                    "message_type": "connect_tool",
-                    "provider": required_provider,
-                }
-
-    # Suppress action_request if the AI is still asking for information.
-    # The AI sometimes emits <action_request> prematurely while still gathering
-    # fields (e.g., asking "what's your email address?"). If the response ends
-    # with an info-gathering question, drop the action request.
-    if action_request_type and not metadata:
-        _last = clean_content.rsplit(".", 1)[-1].strip().lower() or clean_content.lower()
-        if _last.endswith("?") and _re.search(
-            r"\b(what('?s)?|who|which|where|how much|how many)\b", _last
-        ):
-            action_request_type = None
-
-    if action_request_type and not metadata:
-        # Check if the required tool is connected before proceeding
-        # (skip if workflow/schedule metadata is already set — don't override it)
-        required_provider = ACTION_PROVIDER.get(action_request_type)
+    # ── Intent detection via register_intent tool ─────────────────────
+    # If the AI called register_intent, handle the detected action type.
+    # This replaces the old <action_request>/<action_confirmed> tag system.
+    if detected_action and not metadata:
+        required_provider = ACTION_PROVIDER.get(detected_action)
         if required_provider and required_provider not in connected_providers:
-            # Tool not connected — show connect card instead of action card
+            # Tool not connected — show connect card
             provider_name = "Gmail" if required_provider == "gmail" else "Google Calendar"
             clean_content = (
                 f"To do that, we'll need to connect your {provider_name} first. "
@@ -769,70 +942,41 @@ async def chat(request: ChatRequest, db: Session = Depends(get_db)):
                 "message_type": "connect_tool",
                 "provider": required_provider,
             }
+        elif is_auto_execute(detected_action):
+            # Auto-execute actions (list_events, check_availability)
+            params = await extract_action_from_conversation(
+                messages, detected_action, timezone=tz
+            )
+            exec_meta = {"action_type": detected_action, "action_params": params or {}}
+            result = await _execute_chat_action(
+                db, exec_meta, conversation_id=conversation.id
+            )
+            metadata = {
+                "message_type": "action_result",
+                "action_type": detected_action,
+                "success": result["status"] == "success",
+                "details": result.get("details", {}),
+            }
         else:
-            # Extract structured action parameters via a second Claude call
-            params = await extract_action_from_conversation(messages, action_request_type, timezone=tz)
-
-            # Read-only actions execute immediately — no confirmation needed
-            if action_request_type in ("list_events", "check_availability"):
-                exec_meta = {"action_type": action_request_type, "action_params": params or {}}
-                result = await _execute_chat_action(db, exec_meta, conversation_id=conversation.id)
-                metadata = {
-                    "message_type": "action_result",
-                    "action_type": action_request_type,
-                    "success": result["status"] == "success",
-                    "details": result.get("details", {}),
-                }
-            else:
+            # Create form state for confirmation-required actions
+            form = create_form_state(db, conversation.id, detected_action)
+            # Extract any fields already provided in the conversation
+            params = await extract_action_from_conversation(
+                messages, detected_action, timezone=tz
+            )
+            if params:
+                update_form_fields(db, form, params)
+                db.refresh(form)
+            if check_completion(form):
+                # User gave everything in one message — show confirmation card
+                form.status = "ready"
+                db.commit()
                 metadata = {
                     "message_type": "action_request",
-                    "action_type": action_request_type,
-                    "action_params": params or {},
+                    "action_type": detected_action,
+                    "action_params": form.fields or {},
                 }
-
-    if signals["action_confirmed"] and not metadata:
-        # Determine action type: from the confirmed tag, from a prior action_request, or None
-        # (skip if workflow metadata is already set — don't override it)
-        confirmed_val = signals["action_confirmed"]
-        action_meta = _find_latest_action_request(db, conversation.id)
-
-        if isinstance(confirmed_val, str):
-            # Claude included the action type in <action_confirmed>send_email</action_confirmed>
-            action_type = confirmed_val
-        elif action_meta:
-            action_type = action_meta["action_type"]
-        else:
-            action_type = None
-
-        if action_type:
-            # Guard: check if required tool is connected before executing
-            required_provider = ACTION_PROVIDER.get(action_type)
-            if required_provider and required_provider not in connected_providers:
-                provider_name = "Gmail" if required_provider == "gmail" else "Google Calendar"
-                clean_content = (
-                    f"Hmm, it looks like your {provider_name} isn't connected yet. "
-                    "Let's get that set up first!"
-                )
-                metadata = {
-                    "message_type": "connect_tool",
-                    "provider": required_provider,
-                }
-            else:
-                # Re-extract params from the full conversation (captures any additions)
-                fresh_params = await extract_action_from_conversation(
-                    messages, action_type, timezone=tz
-                )
-                exec_meta = {
-                    "action_type": action_type,
-                    "action_params": fresh_params or (action_meta or {}).get("action_params", {}),
-                }
-                result = await _execute_chat_action(db, exec_meta, conversation_id=conversation.id)
-                metadata = {
-                    "message_type": "action_result",
-                    "action_type": action_type,
-                    "success": result["status"] == "success",
-                    "details": result.get("details", {}),
-                }
+            # Otherwise form stays "collecting" — AI's response already asks
 
     # ── Workflow management (pause / resume / delete) ──────────────────
     if signals["workflow_manage"]:
@@ -963,9 +1107,6 @@ async def chat(request: ChatRequest, db: Session = Depends(get_db)):
     )
 
 
-import re as _re
-
-
 def _detect_tool_from_user_intent(message: str, connected_providers: list) -> Optional[str]:
     """Check if the user's message implies they need a tool that isn't connected.
 
@@ -1005,81 +1146,26 @@ def _detect_tool_from_user_intent(message: str, connected_providers: list) -> Op
     return None
 
 
-def _detect_action_gathering(content: str) -> Optional[str]:
-    """Detect if the AI is engaging with an action request instead of suggesting connection.
-
-    Catches any response where the AI is proceeding with an email or calendar task
-    (gathering fields, offering choices, disambiguating) without suggesting a tool connection.
-    """
-    lower = content.lower()
-    # Must contain a question — the AI is asking the user something
-    if "?" not in lower:
-        return None
-    # Email: any response that engages with sending email
-    email_signals = [
-        "subject", "body", "email say", "email should", "send that email",
-        "send an email", "send the email", "draft", "write the email",
-        "who should i", "who do you want", "recipient", "send it to",
+def _is_affirmative(message: str) -> bool:
+    """Check if a user message is confirming an action."""
+    lower = message.strip().lower()
+    affirmatives = [
+        "yes", "yeah", "yep", "yup", "sure", "go ahead", "do it",
+        "sounds good", "looks good", "perfect", "confirmed", "ok", "okay",
+        "go for it", "send it", "create it", "book it", "let's do it",
+        "that's right", "correct", "absolutely",
     ]
-    if any(s in lower for s in email_signals):
-        return "send_email"
-    # Calendar: any response that engages with calendar/scheduling
-    cal_signals = [
-        "event", "meeting", "appointment", "schedule", "put on your calendar",
-        "add to your calendar", "block off", "what time", "how long should",
-        "your calendar", "time slot", "availability", "available",
-        "what's on", "show you", "check if", "free", "busy",
+    return any(a in lower for a in affirmatives)
+
+
+def _is_negative(message: str) -> bool:
+    """Check if a user message is cancelling an action."""
+    lower = message.strip().lower()
+    negatives = [
+        "no", "nope", "cancel", "never mind", "nevermind", "stop",
+        "forget it", "don't", "scratch that",
     ]
-    if any(s in lower for s in cal_signals):
-        return "check_availability"
-    return None
-
-
-def _detect_action_from_content(content: str) -> Optional[str]:
-    """Fallback: detect if the AI response is asking for confirmation of an action.
-
-    Returns the action type if detected, None otherwise.
-    """
-    lower = content.lower()
-
-    # If the response ends with a question gathering information (what, who,
-    # which, where, how), it's still collecting fields — NOT confirming.
-    # Only the LAST sentence matters; confirmation phrases earlier in the
-    # response (e.g., recapping "you want me to...") are not confirmation.
-    last_sentence = lower.rsplit(".", 1)[-1].strip()
-    if not last_sentence:
-        last_sentence = lower
-    info_gathering = _re.search(
-        r"\b(what('?s)?|who|which|where|how much|how many|what address|what email)\b",
-        last_sentence,
-    )
-    if info_gathering and last_sentence.rstrip().endswith("?"):
-        return None
-
-    # Must contain a confirmation question
-    # Check only the tail end of the response (last ~200 chars) to avoid
-    # matching recap phrases like "you mentioned you want me to..."
-    tail = lower[-200:] if len(lower) > 200 else lower
-    confirmation_phrases = [
-        "sound good", "want me to", "shall i", "go ahead",
-        "ready to", "look right", "look correct", "that right",
-        "does that work", "want me to go", "should i",
-    ]
-    has_confirmation = any(phrase in tail for phrase in confirmation_phrases)
-    if not has_confirmation:
-        return None
-
-    # Detect action type from keywords
-    if _re.search(r"\bemail\b|\bsend\b.*\bto\b.*@", lower):
-        return "send_email"
-    if _re.search(r"\bevent\b|\bcalendar\b|\bmeeting\b|\bappointment\b", lower):
-        return "create_event"
-    if _re.search(r"\bavailab|\bfree\b|\bbusy\b|\bopen\b.*\bslot", lower):
-        return "check_availability"
-    if _re.search(r"\badd\b.*\b(attend|invite)\b|\binvite\b.*\bto\b", lower):
-        return "update_event"
-
-    return None
+    return any(n in lower for n in negatives)
 
 
 def _find_latest_draft(db: Session, conversation_id: int) -> Optional[dict]:

--- a/backend/app/services/ai_engine.py
+++ b/backend/app/services/ai_engine.py
@@ -43,96 +43,43 @@ Before treating ANYTHING as an immediate action, check for recurrence words: \
 If the user's message contains ANY of these, this is NOT an immediate action — \
 skip this section entirely and go to WORKFLOW SETUP below. \
 Even if the task involves sending email or creating events, if it repeats, it is a WORKFLOW. \
-NEVER use <action_request> for recurring tasks. ALWAYS use the workflow discovery flow.
+NEVER call register_intent for recurring tasks. ALWAYS use the workflow discovery flow.
 
 If the user asks you to do something right now (a single one-time action, not recurring), \
-treat it as an immediate action. Recognize requests like:
+call the register_intent tool with the appropriate action_type:
 - "Send Jane a welcome email at jane@example.com" → send_email
 - "Create a calendar event for Friday at 2pm" → create_event
-- "What's on my calendar tomorrow?" or "Check my availability for Friday" or "What do I have this week?" → list_events
+- "What's on my calendar tomorrow?" or "What do I have this week?" → list_events
 - "Is 2pm to 3pm open tomorrow?" or "Am I free at 10am on Friday?" → check_availability
-- "Add Jane to that event" or "Send an invite for that meeting to jane@example.com" → update_event
+- "Add Jane to that event" or "Send an invite for that meeting" → update_event
 
 IMPORTANT — list_events vs check_availability:
-- Use list_events when the user clearly wants to SEE what's on their calendar — "what's my day look like," \
-"what do I have tomorrow," "show me my schedule." This shows their actual events.
-- Use check_availability ONLY when the user asks about a SPECIFIC time slot — "is 2pm free," \
-"can I do 3-4pm on Friday," "is there an opening at noon." This checks if a particular window is open.
-- If it's AMBIGUOUS (e.g., "check my availability tomorrow"), ASK which they mean:
-"Sure! Would you like me to:
-• Show you what's on your calendar tomorrow
-• Check if a specific time slot is open?"
-Do NOT guess — ask first.
+- Use list_events when the user wants to SEE their calendar — "what's my day look like," \
+"show me my schedule." Use check_availability ONLY for a SPECIFIC time slot — "is 2pm free," \
+"can I do 3-4pm on Friday." If AMBIGUOUS, ASK which they mean.
 
 IMPORTANT — create_event vs check_availability:
-- If the user asks "can I make an event at [time]?", "is there room for a meeting at [time]?", \
-or anything that sounds like they want to know IF they can schedule something — treat it as \
-check_availability, NOT create_event. The word "can" signals they're asking about availability.
-- Only use create_event when the user is clearly TELLING you to create it — "create a meeting," \
-"schedule a standup," "put a 30-min block on my calendar." These are commands, not questions.
-- If it's ambiguous, ASK:
-"Would you like me to:
-• Check if that time slot is open first
-• Go ahead and create the event?"
+- "Can I make an event at [time]?" = check_availability (asking about availability). \
+"Create a meeting" / "schedule a standup" = create_event (a command). If ambiguous, ASK.
 
-REQUIRED FIELDS — you MUST have ALL of these before showing a confirmation:
-- send_email: (1) recipient email address(es) — can be one or multiple, (2) subject line, (3) what the email should say. \
-Optional: CC and BCC recipients. If the user mentions CC or BCC, ask who to include.
-- create_event: (1) event title, (2) date and time, (3) duration or end time
-- update_event: (1) which event (from this conversation), (2) what to change (attendees to add, new title, etc.)
-- check_availability: (1) specific start time, (2) specific end time (not a whole day — a specific window like 2pm-3pm). \
-Once you have BOTH times, SKIP confirmation — just say something like "Let me check if that time is open" \
-and include the <action_request>check_availability</action_request> tag right away. Do NOT ask "sound good?" — just do it.
-- list_events: no required fields — SKIP confirmation entirely. Just say something like \
-"Let me check your calendar for Friday" and include the <action_request>list_events</action_request> tag \
-right away. Do NOT ask "sound good?" for listing events — just do it.
+After calling register_intent, respond naturally. The system will tell you which field \
+to ask about next. When the system says a field is needed, ask ONE natural question \
+about it. Offer 2-3 choices when possible. Do NOT present confirmation summaries — \
+the system shows a confirmation card automatically when all fields are collected.
 
-GATHERING FLOW — follow this strictly (except list_events and check_availability, which skip confirmation as noted above):
-1. When you recognize an action intent, check which required fields are STILL MISSING.
-2. If ANY required field is missing, ask ONE follow-up question about the NEXT missing field. \
-Do NOT include any hidden tags. Do NOT summarize or confirm yet. Just ask about the one missing piece. \
-Offer 2-3 choices when possible. Examples:
-   - Missing recipient: "Who should I send this to? Do you have their email address?"
-   - Missing subject: "What should the subject line be?"
-   - Missing body: "What should the email say? Something like a quick welcome, a detailed intro, or \
-do you want to tell me the gist and I'll draft it?"
-   - Missing date: "When should this be? Today, tomorrow, or a specific day?"
-   - Missing time: "What time works best — morning, afternoon, or a specific time?"
-   - Missing duration: "How long should it be — 30 minutes, an hour, or something else?"
-   - Missing time range: "What time range should I check — morning (9 AM–12 PM), afternoon (12–5 PM), \
-or a specific window?"
-3. Keep asking ONE question per turn until every required field is filled. Do NOT skip ahead.
-4. Once you have ALL required fields, present a clear confirmation summary that restates every \
-detail, then ask "Sound good?" or "Ready to go?". For example:
-   - "Here's what I'll do: Send an email to jane@example.com with the subject 'Welcome!' \
-that says 'Hi Jane, welcome aboard! We're excited to have you.' — sound good?"
-   - "I'll create a 'Team Standup' event for tomorrow (April 9) from 2:00 PM to 2:30 PM — ready to go?"
-5. At the very end of that confirmation message (after everything else), append this hidden tag on its own line:
-<action_request>ACTION_TYPE</action_request>
-Replace ACTION_TYPE with one of: send_email, create_event, update_event, check_availability, list_events
-Use update_event (not create_event) when the user wants to modify an event that was just created \
-in this conversation — like adding attendees, changing the title, or sending invites for it.
+When the user confirms an action ("yes," "go ahead," "sounds good") and you see a \
+[System: confirmation card] note, just say something short like "On it!" The system \
+handles execution automatically.
 
-IMPORTANT: NEVER include <action_request> until you have confirmed ALL required fields with the user. \
-If you are still missing any field, just ask about it — no tags.
+If the user says "no" or wants to change something, help them adjust — the system \
+will re-collect the updated fields.
 
-NEVER include any hidden tags (<action_request>, <action_confirmed>, etc.) when the user is:
-- Asking about your capabilities ("can you check my calendar?", "do you have access to...?")
-- Complaining about or questioning a previous result ("why did it say that?", "that's wrong")
-- Making conversation or asking a follow-up about results you already fetched
-Only include action tags when the user is making a GENUINE NEW REQUEST to do something. \
-If you already checked their calendar and they ask about it, just refer to the [System: ...] \
-results you already have — do NOT re-execute the action.
-
-When the user confirms the action ("yes," "go ahead," "do it," "sounds good"):
-1. Respond with something short like "On it — let me take care of that!"
-2. At the very end of your message, append this hidden tag on its own line:
-<action_confirmed>ACTION_TYPE</action_confirmed>
-Replace ACTION_TYPE with the same type you used in the action_request tag (e.g., send_email, create_event, etc.).
-
-If the user says "no" or wants to change something about the action, ask what specifically to change. \
-Once they provide the change, re-present the FULL updated confirmation summary with ALL details \
-and include the <action_request> tag again.
+Do NOT call register_intent when the user is:
+- Asking about your capabilities ("can you check my calendar?")
+- Questioning a previous result ("that's wrong")
+- Making conversation or asking about results you already fetched
+Only call register_intent for GENUINE NEW REQUESTS. \
+If you already checked their calendar, refer to the [System: ...] results — do NOT re-execute.
 
 WORKFLOW SETUP — SET UP A RECURRING PROCESS:
 
@@ -584,25 +531,18 @@ def parse_ai_response(raw_content: str) -> dict:
     """Strip hidden signal tags from AI response and return flags.
 
     Returns dict with keys: clean_content, workflow_ready, workflow_confirmed,
-    action_request (str or None), action_confirmed,
-    workflow_manage (dict or None), workflow_manage_confirmed (dict or None).
+    workflow_manage (dict or None), workflow_manage_confirmed (dict or None),
+    and other workflow/tool signal flags.
+
+    NOTE: action_request and action_confirmed tags have been removed — intent
+    detection now uses the register_intent tool_use mechanism in get_ai_response().
     """
     workflow_ready = "<workflow_ready>true</workflow_ready>" in raw_content
     workflow_confirmed = "<workflow_confirmed>true</workflow_confirmed>" in raw_content
 
-    # Extract action_request type (e.g., "send_email" from <action_request>send_email</action_request>)
-    action_request = None
+    # Strip any leftover action tags the AI may still emit (defensive cleanup)
     action_match = re.search(r"<action_request>(\w+)</action_request>", raw_content)
-    if action_match:
-        action_request = action_match.group(1)
-
-    # Extract action_confirmed — supports both <action_confirmed>true</action_confirmed>
-    # and <action_confirmed>send_email</action_confirmed> (with action type)
-    action_confirmed = None
     confirmed_match = re.search(r"<action_confirmed>(\w+)</action_confirmed>", raw_content)
-    if confirmed_match:
-        val = confirmed_match.group(1)
-        action_confirmed = val if val != "true" else True
 
     # Extract workflow_manage (e.g., <workflow_manage>pause:New client welcome</workflow_manage>)
     workflow_manage = None
@@ -743,8 +683,6 @@ def parse_ai_response(raw_content: str) -> dict:
         "clean_content": clean,
         "workflow_ready": workflow_ready,
         "workflow_confirmed": workflow_confirmed,
-        "action_request": action_request,
-        "action_confirmed": action_confirmed,
         "workflow_manage": workflow_manage,
         "workflow_manage_confirmed": workflow_manage_confirmed,
         "connect_tool": connect_tool,
@@ -761,6 +699,36 @@ def parse_ai_response(raw_content: str) -> dict:
         "workflow_edit_confirmed": workflow_edit_confirmed,
         "choices": choices,
     }
+
+
+# ── Intent detection tool (replaces <action_request> signal tags) ───────────
+
+REGISTER_INTENT_TOOL = {
+    "name": "register_intent",
+    "description": (
+        "Call this when you recognize the user wants to perform an immediate "
+        "one-time action right now (NOT a recurring/automated workflow). "
+        "Examples: 'send Jane an email', 'create a meeting for Friday', "
+        "'what's on my calendar tomorrow', 'is 2pm free?'"
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "action_type": {
+                "type": "string",
+                "enum": [
+                    "send_email",
+                    "create_event",
+                    "update_event",
+                    "check_availability",
+                    "list_events",
+                ],
+                "description": "The type of action the user wants to perform",
+            },
+        },
+        "required": ["action_type"],
+    },
+}
 
 
 # ── Action extraction tools ─────────────────────────────────────────────────
@@ -1260,8 +1228,15 @@ async def get_ai_response(
     timezone: str = "UTC",
     workflow_names: Optional[List[str]] = None,
     connected_providers: Optional[List[str]] = None,
-) -> str:
-    """Send messages to Claude and return the assistant's response."""
+    form_context: Optional[str] = None,
+    include_intent_tool: bool = True,
+) -> Tuple[str, Optional[str]]:
+    """Send messages to Claude and return (text, detected_action_type).
+
+    When *include_intent_tool* is True the AI may call ``register_intent``
+    to signal an immediate-action intent.  The detected action_type (or None)
+    is returned as the second element of the tuple.
+    """
     from datetime import datetime, timezone as tz
 
     from datetime import timedelta
@@ -1300,13 +1275,33 @@ async def get_ai_response(
         system += "\n\nThe owner has no saved processes yet. If they ask to see their workflows, " \
                   "still use <workflow_list>true</workflow_list> — the system will show an empty state."
 
-    response = await client.messages.create(
+    # Append form state context when actively collecting fields
+    if form_context:
+        system += form_context
+
+    # Build API kwargs — include intent tool when not already collecting fields
+    api_kwargs: Dict = dict(
         model=CLAUDE_MODEL,
         max_tokens=1024,
         system=system,
         messages=messages,
     )
-    return response.content[0].text
+    if include_intent_tool:
+        api_kwargs["tools"] = [REGISTER_INTENT_TOOL]
+        api_kwargs["tool_choice"] = {"type": "auto"}
+
+    response = await client.messages.create(**api_kwargs)
+
+    # Parse response content blocks — may contain text and/or tool_use
+    text_parts: List[str] = []
+    detected_action: Optional[str] = None
+    for block in response.content:
+        if block.type == "text":
+            text_parts.append(block.text)
+        elif block.type == "tool_use" and block.name == "register_intent":
+            detected_action = block.input.get("action_type")
+
+    return ("\n".join(text_parts), detected_action)
 
 
 async def extract_workflow_from_conversation(messages: List[Dict[str, str]]) -> Optional[dict]:

--- a/backend/app/services/form_state.py
+++ b/backend/app/services/form_state.py
@@ -1,0 +1,247 @@
+"""Backend state machine for immediate-action field collection.
+
+Replaces the AI-driven signal tag system (<action_request>, <action_confirmed>)
+with deterministic field tracking. The backend controls what card appears and when.
+"""
+
+from typing import Optional, Tuple, Dict, Any
+
+from sqlalchemy.orm import Session
+
+from app.models.action_form import ActionFormState
+
+
+# ---------------------------------------------------------------------------
+# Field schemas — source of truth for what each action type requires
+# ---------------------------------------------------------------------------
+
+REQUIRED_FIELD_SCHEMAS: Dict[str, dict] = {
+    "send_email": {
+        "required": ["recipient", "subject", "body"],
+        "optional": ["cc", "bcc"],
+        "auto_execute": False,
+    },
+    "create_event": {
+        "required": ["summary", "start_time", "end_time"],
+        "optional": ["description", "attendees"],
+        "auto_execute": False,
+    },
+    "update_event": {
+        "required": [],  # At least one optional field must be set
+        "optional": ["add_attendees", "summary"],
+        "auto_execute": False,
+    },
+    "list_events": {
+        "required": [],
+        "optional": ["time_min", "time_max"],
+        "auto_execute": True,
+    },
+    "check_availability": {
+        "required": ["start_time", "end_time"],
+        "optional": [],
+        "auto_execute": False,
+        "skip_confirmation": True,  # Execute immediately once fields are filled
+    },
+}
+
+# Trigger field schemas (for documentation and future workflow state machine)
+TRIGGER_FIELD_SCHEMAS: Dict[str, dict] = {
+    "calendar_event_created": {
+        "required": ["description"],
+        "optional": [
+            "summary_contains",
+            "attendee_email",
+            "description_contains",
+            "min_duration_minutes",
+        ],
+    },
+    "calendar_event_starting": {
+        "required": ["lead_time_minutes", "description"],
+        "optional": [
+            "summary_contains",
+            "attendee_email",
+            "description_contains",
+            "min_duration_minutes",
+        ],
+    },
+    "email_received": {
+        "required": ["gmail_query_description"],
+        "optional": [],
+    },
+    "schedule": {
+        "required": ["frequency", "schedule_time"],
+        "optional": [],
+    },
+}
+
+# Human-readable prompts for each field — tells the AI what to ask about
+FIELD_PROMPTS: Dict[str, str] = {
+    "recipient": "who to send the email to (their email address)",
+    "subject": "the email subject line",
+    "body": "what the email should say",
+    "cc": "who to CC on the email",
+    "bcc": "who to BCC on the email",
+    "summary": "the event title/name",
+    "start_time": "when it should start (date and time)",
+    "end_time": "when it should end, or how long it should be",
+    "description": "any notes or description to include",
+    "attendees": "who to invite (their email addresses)",
+    "add_attendees": "who to add to the event (their email addresses)",
+}
+
+ACTION_LABELS: Dict[str, str] = {
+    "send_email": "send an email",
+    "create_event": "create a calendar event",
+    "update_event": "update a calendar event",
+    "check_availability": "check calendar availability",
+    "list_events": "list calendar events",
+}
+
+
+# ---------------------------------------------------------------------------
+# Form state CRUD
+# ---------------------------------------------------------------------------
+
+
+def get_active_form(db: Session, conversation_id: int) -> Optional[ActionFormState]:
+    """Return the active form state for a conversation (collecting or ready)."""
+    return (
+        db.query(ActionFormState)
+        .filter(
+            ActionFormState.conversation_id == conversation_id,
+            ActionFormState.status.in_(["collecting", "ready"]),
+        )
+        .first()
+    )
+
+
+def create_form_state(
+    db: Session, conversation_id: int, action_type: str
+) -> ActionFormState:
+    """Create a new form state, cancelling any existing active form first."""
+    existing = get_active_form(db, conversation_id)
+    if existing:
+        existing.status = "cancelled"
+        db.flush()
+
+    schema = REQUIRED_FIELD_SCHEMAS.get(action_type, {"required": [], "optional": []})
+    fields = {f: None for f in schema["required"]}
+
+    form = ActionFormState(
+        conversation_id=conversation_id,
+        action_type=action_type,
+        fields=fields,
+        status="collecting",
+    )
+    db.add(form)
+    db.commit()
+    db.refresh(form)
+    return form
+
+
+def update_form_fields(
+    db: Session, form_state: ActionFormState, extracted: Dict[str, Any]
+) -> None:
+    """Merge extracted field values into the form state (non-null values only)."""
+    current = dict(form_state.fields) if form_state.fields else {}
+    changed = False
+    for key in current:
+        val = extracted.get(key)
+        if val is not None:
+            current[key] = val
+            changed = True
+    # Also pick up optional fields if they were provided
+    schema = REQUIRED_FIELD_SCHEMAS.get(
+        form_state.action_type, {"required": [], "optional": []}
+    )
+    for key in schema.get("optional", []):
+        val = extracted.get(key)
+        if val is not None:
+            current[key] = val
+            changed = True
+    if changed:
+        form_state.fields = current
+        db.commit()
+        db.refresh(form_state)
+
+
+def check_completion(form_state: ActionFormState) -> bool:
+    """Return True if all required fields are non-null."""
+    schema = REQUIRED_FIELD_SCHEMAS.get(
+        form_state.action_type, {"required": [], "optional": []}
+    )
+    required = schema["required"]
+    if not required:
+        # update_event: at least one optional field must be set
+        if form_state.action_type == "update_event":
+            return any(v is not None for v in (form_state.fields or {}).values())
+        return True
+    fields = form_state.fields or {}
+    return all(fields.get(f) is not None for f in required)
+
+
+def get_next_missing_field(form_state: ActionFormState) -> Optional[Tuple[str, str]]:
+    """Return (field_name, prompt_hint) for the next missing required field."""
+    schema = REQUIRED_FIELD_SCHEMAS.get(
+        form_state.action_type, {"required": [], "optional": []}
+    )
+    fields = form_state.fields or {}
+    for f in schema["required"]:
+        if fields.get(f) is None:
+            return (f, FIELD_PROMPTS.get(f, f))
+    return None
+
+
+def build_form_context(form_state: ActionFormState) -> str:
+    """Build a system prompt addendum describing the active field collection."""
+    fields = form_state.fields or {}
+    filled = {k: v for k, v in fields.items() if v is not None}
+    missing = get_next_missing_field(form_state)
+
+    label = ACTION_LABELS.get(form_state.action_type, form_state.action_type)
+
+    if missing is None:
+        # No required fields missing — but for all-optional actions (update_event),
+        # prompt for the first optional field if nothing has been collected yet
+        if not filled:
+            schema = REQUIRED_FIELD_SCHEMAS.get(form_state.action_type, {})
+            optional = schema.get("optional", [])
+            if optional:
+                first_opt = optional[0]
+                hint = FIELD_PROMPTS.get(first_opt, first_opt)
+                return (
+                    f"\n\nACTIVE ACTION: The user is working on: {label}.\n"
+                    f"NEXT FIELD NEEDED: {first_opt} — {hint}.\n"
+                    "Ask ONE natural question about this field. "
+                    "Offer 2-3 choices when possible."
+                )
+        # All fields collected — tell AI to write a brief confirmation
+        return (
+            f"\n\nACTIVE ACTION: The user is working on: {label}.\n"
+            f"Collected so far: {filled}\n"
+            "All required fields are collected. Write a brief confirmation summary "
+            "like 'Here\\'s what I\\'ll do:' — the system will show a details card automatically."
+        )
+
+    field_name, prompt_hint = missing
+    parts = [f"\n\nACTIVE ACTION: The user is working on: {label}."]
+    if filled:
+        parts.append(f"Already collected: {filled}")
+    parts.append(
+        f"NEXT FIELD NEEDED: {field_name} — {prompt_hint}.\n"
+        "Ask ONE natural question about this field. Offer 2-3 choices when possible. "
+        "Do NOT summarize or confirm yet — the system handles that automatically."
+    )
+    return "\n".join(parts)
+
+
+def is_auto_execute(action_type: str) -> bool:
+    """Return True if this action type should execute immediately without confirmation."""
+    schema = REQUIRED_FIELD_SCHEMAS.get(action_type, {})
+    return schema.get("auto_execute", False)
+
+
+def is_skip_confirmation(action_type: str) -> bool:
+    """Return True if this action type should execute once fields are filled (no confirmation card)."""
+    schema = REQUIRED_FIELD_SCHEMAS.get(action_type, {})
+    return schema.get("skip_confirmation", False)


### PR DESCRIPTION
## Summary
- Replace AI-driven signal tags (`<action_request>`, `<action_confirmed>`) with a deterministic backend state machine
- AI signals intent via `register_intent` tool_use — backend controls field collection and confirmation card timing
- New `ActionFormState` DB model tracks field collection per conversation with status flow: `collecting` → `ready` → `executed`
- New `REQUIRED_FIELD_SCHEMAS` registry defines required/optional fields per action type
- Remove content-based fallbacks (`_detect_action_from_content`, `_detect_action_gathering`)
- Workflow signal tags (`workflow_ready`, `workflow_confirmed`, etc.) are completely unchanged

## Test plan
- [ ] **Send email flow**: Start a new chat → type "Send Jane a welcome email at jane@example.com" → AI should ask about subject → provide subject → AI asks about body → provide body → confirmation card appears automatically → say "yes" → email sends
- [ ] **Create event flow**: Type "Create a meeting for Friday at 2pm for 30 minutes called Team Standup" → if all fields provided, confirmation card should appear immediately → confirm → event created
- [ ] **Auto-execute (list events)**: Type "What's on my calendar tomorrow?" → should execute immediately and show results (no confirmation card)
- [ ] **Auto-execute (check availability)**: Type "Is 2pm to 3pm open tomorrow?" → should collect times via form then execute immediately (no confirmation card)
- [ ] **Premature confirmation prevention**: Type "I want to send an email" → should NOT show confirmation card yet → should ask about recipient first
- [ ] **User cancellation**: Mid-field-collection, type "never mind" → should cancel and return to normal chat
- [ ] **Field correction**: After providing a subject, type "actually change the subject to Hello" → should update the field
- [ ] **Workflow regression**: Type "Every morning at 9am, send me a summary email" → should trigger workflow discovery flow (NOT the action state machine)
- [ ] **Tool connection**: With Gmail disconnected, type "send an email" → should show connect card (not crash)
- [ ] **Second action in same conversation**: Complete one action, then start another in the same chat → should work without errors

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)